### PR TITLE
Use single account for evm transfers.

### DIFF
--- a/evm-utils/evm-rpc/src/lib.rs
+++ b/evm-utils/evm-rpc/src/lib.rs
@@ -47,21 +47,6 @@ pub struct RPCLog {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct RPCReceipt {
-    pub transaction_hash: Hex<H256>,
-    pub transaction_index: Hex<usize>,
-    pub block_hash: Hex<H256>,
-    pub block_number: Hex<U256>,
-    pub cumulative_gas_used: Hex<Gas>,
-    pub gas_used: Hex<Gas>,
-    pub contract_address: Option<Hex<Address>>,
-    pub logs: Vec<RPCLog>,
-    pub root: Hex<H256>,
-    pub status: Hex<usize>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
 pub struct RPCBlock {
     pub number: Hex<U256>,
     pub hash: Hex<H256>,
@@ -106,6 +91,20 @@ pub struct RPCTransaction {
     pub transaction_index: Option<Hex<usize>>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RPCReceipt {
+    pub transaction_hash: Hex<H256>,
+    pub transaction_index: Hex<usize>,
+    pub block_hash: Hex<H256>,
+    pub block_number: Hex<U256>,
+    pub cumulative_gas_used: Hex<Gas>,
+    pub gas_used: Hex<Gas>,
+    pub contract_address: Option<Hex<Address>>,
+    pub logs: Vec<RPCLog>,
+    pub root: Hex<H256>,
+    pub status: Hex<usize>,
+}
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RPCTrace {

--- a/evm-utils/evm-state/src/lib.rs
+++ b/evm-utils/evm-state/src/lib.rs
@@ -222,19 +222,7 @@ pub mod tests {
         let code = hex::decode(HELLO_WORLD_CODE).unwrap();
         let data = hex::decode(HELLO_WORLD_ABI).unwrap();
 
-        let vicinity = MemoryVicinity {
-            gas_price: U256::zero(),
-            origin: H160::default(),
-            chain_id: U256::zero(),
-            block_hashes: Vec::new(),
-            block_number: U256::zero(),
-            block_coinbase: H160::default(),
-            block_timestamp: U256::zero(),
-            block_difficulty: U256::zero(),
-            block_gas_limit: U256::max_value(),
-        };
-
-        let backend = EvmState::new(vicinity);
+        let backend = EvmState::new();
         let backend = RwLock::new(backend);
 
         {
@@ -256,6 +244,7 @@ pub mod tests {
             backend.read().unwrap().try_fork().unwrap(),
             config,
             usize::max_value(),
+            0,
         );
 
         let exit_reason = match executor.with_executor(|e| {

--- a/evm-utils/programs/evm_loader/src/instructions.rs
+++ b/evm-utils/programs/evm_loader/src/instructions.rs
@@ -1,6 +1,5 @@
 use super::scope::*;
 use serde::{Deserialize, Serialize};
-use solana_sdk::instruction::InstructionError;
 
 #[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize)]
 pub enum EvmInstruction {
@@ -8,24 +7,11 @@ pub enum EvmInstruction {
     ///
     ///
     EvmTransaction { evm_tx: evm::Transaction },
-
-    /// Create Intermediate account, to allow evm manage your native tokens.
-    ///
-    /// Outer args:
-    /// account_key[0] - `[writable]. Evm state account, used for lock.
-    /// account_key[1] - `[writable]`. Authority account that is
-    /// account_key[2] - `[read]`. Rent sysvar
-    ///
-    /// Inner args:
-    /// pubkey - owner pubkey, that will be allowed to manage withdrawals and deposits for this accounts.
-    ///
-    CreateDepositAccount { pubkey: solana::Address },
     /// Transfer native lamports to ethereum.
     ///
     /// Outer args:
     /// account_key[0] - `[writable]. Evm state account, used for lock.
-    /// account_key[1] - `[read, signer]`. Owner account that's allowed to manage withdrawal of authority account.
-    /// account_key[2] - `[writable]`. Authority account that was created in CreateDepositAccount
+    /// account_key[1] - `[writable, signer]`. Owner account that's allowed to manage withdrawal of his account by transfering ownership.
     ///
     /// Inner args:
     /// amount - count of lamports to be transfered.
@@ -35,52 +21,27 @@ pub enum EvmInstruction {
         lamports: u64,
         ether_address: evm::Address,
     },
-    // TODO: Transfer eth to sol back
-
-    // /// Transfer native lamports to ethereum.
-    // ///
-    // /// Outer args:
-    // /// account_key[0] - `[]`.
-    // ///
-    // /// Inner args:
-    // /// amount - count of lamports to be transfered.
-    // /// ether_key - etherium address.
+    /// Transfer user account ownership back to system program.
+    ///
+    /// Outer args:
+    /// account_key[0] - `[writable]. Evm state account, used for lock.
+    /// account_key[1] - `[writable, signer]`. Owner account that's allowed to manage withdrawal of his account by transfering ownership.
+    ///
+    FreeOwnership {},
+    // / Transfer gweis to solana lamports.
+    // /
+    // / Outer args:
+    // / account_key[0] - `[writable]. Evm state account, used for lock.
+    // / account_key[1] - `[writable, signer]`. Owner account that's allowed to manage withdrawal of his account by transfering ownership.
+    // /
+    // / Inner args:
+    // / amount - count of lamports to be transfered.
+    // / ether_key - recevier etherium address.
+    // /
     // SwapEtherToNative {
     //     amount: u64,
     //     ether_key: evm::Address,
     //     account_key: solana::Address,
     //     ether_signature: evm::Signature,
     // }
-}
-
-/// Mint data.
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq)]
-pub struct Deposit {
-    pub deposit_authority: Option<solana::Address>,
-    pub locked_lamports: u64,
-    pub is_initialized: bool,
-}
-
-impl Deposit {
-    pub const LEN: usize = 42;
-
-    pub fn get_owner(&self) -> Result<solana::Address, InstructionError> {
-        self.deposit_authority
-            .ok_or(InstructionError::AccountBorrowFailed)
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    #[test]
-    fn test_len() {
-        let deposit = Deposit {
-            deposit_authority: Some(solana::Address::default()),
-            locked_lamports: 123,
-            is_initialized: true,
-        };
-        let data = bincode::serialize(&deposit).unwrap();
-        assert_eq!(data.len(), Deposit::LEN)
-    }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1259,6 +1259,8 @@ impl Bank {
         // Add account for evm.
         let account = native_loader::create_loadable_account("Evm Processor");
         self.store_account(&solana_sdk::evm_loader::id(), &account);
+        let account = solana_evm_loader_program::create_state_account();
+        self.store_account(&solana_sdk::evm_state::id(), &account);
     }
 
     pub fn add_native_program(&self, name: &str, program_id: &Pubkey) {


### PR DESCRIPTION
Depend on #28 

Closes: #29

Use single account to lock solana funds. Also this account will collect all evm history, and carry evm-lock