### PR TITLE
chore(validator): Temporary fix for gateway.

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1992,13 +1992,7 @@ pub fn main() {
         _ => unreachable!(),
     };
 
-    let identity_keypair = Arc::new(keypair_of(&matches, "identity").unwrap_or_else(|| {
-        clap::Error::with_description(
-            "The --identity <KEYPAIR> argument is required",
-            clap::ErrorKind::ArgumentNotFound,
-        )
-        .exit();
-    }));
+    let identity_keypair = Arc::new(keypair_of(&matches, "identity").unwrap_or_else(Keypair::new));
 
     let authorized_voter_keypairs = keypairs_of(&matches, "authorized_voter_keypairs")
         .map(|keypairs| keypairs.into_iter().map(Arc::new).collect())


### PR DESCRIPTION
Revert identity creation, when no identity provided.