### PR TITLE
fix(velas-chain): Downgrade Rust toolchain and CI environment to version 1.54.

### DIFF
--- a/ci/docker-rust-nightly/Dockerfile
+++ b/ci/docker-rust-nightly/Dockerfile
@@ -1,4 +1,4 @@
-FROM solanalabs/rust:1.55.0
+FROM solanalabs/rust:1.54.0
 ARG date
 
 RUN set -x \

--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -1,6 +1,6 @@
 # Note: when the rust version is changed also modify
 # ci/rust-version.sh to pick up the new image tag
-FROM rust:1.55.0
+FROM rust:1.54.0
 
 # Add Google Protocol Buffers for Libra's metrics library.
 ENV PROTOC_VERSION 3.8.0

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -18,7 +18,7 @@
 if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
-  stable_version=1.55.0
+  stable_version=1.54.0
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.55.0"
+channel = "1.54.0"
 profile = "minimal"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
#### Problem
Recent updates to Cargo  (1.55+) caused problems with environment variables in `build.rs` scripts. 
Related issue: https://github.com/rust-lang/cargo/issues/10111

#### Summary of Changes
Temporary downgrade toolchain version and CI environment to Rust stable 1.54 until clarification of the new behavior
