### PR TITLE
Fix(rpc): Add check to avoid querying bigtable for future evm blocks

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2087,24 +2087,27 @@ impl JsonRpcRequestProcessor {
         receipt
     }
     pub fn get_evm_block_by_id(&self, id: evm_state::BlockNum) -> Option<(evm_state::Block, bool)> {
-        let block = self.blockstore.get_evm_block(id).ok();
+        if id <= self.get_last_available_evm_block()? {
+            let block = self.blockstore.get_evm_block(id).ok();
 
-        if block.is_none() {
-            if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
-                let bigtable_block = self
-                    .runtime
-                    .block_on(bigtable_ledger_storage.get_evm_confirmed_full_block(id))
-                    .ok();
+            if block.is_none() {
+                if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
+                    let bigtable_block = self
+                        .runtime
+                        .block_on(bigtable_ledger_storage.get_evm_confirmed_full_block(id))
+                        .ok();
 
-                // bigtable store only confirmed slots
-                return bigtable_block.map(|b| {
-                    let above_our_chain = self.blockstore.last_root() < b.header.native_chain_slot;
-                    // return confirmed if we have seen it before.
-                    (b, !above_our_chain)
-                });
+                    // bigtable store only confirmed slots
+                    return bigtable_block.map(|b| {
+                        let above_our_chain = self.blockstore.last_root() < b.header.native_chain_slot;
+                        // return confirmed if we have seen it before.
+                        (b, !above_our_chain)
+                    });
+                }
             }
+            return block;
         }
-        block
+        None
     }
 
     pub fn get_evm_block_id_by_hash(&self, hash: evm_state::H256) -> Option<u64> {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2087,25 +2087,35 @@ impl JsonRpcRequestProcessor {
         receipt
     }
     pub fn get_evm_block_by_id(&self, id: evm_state::BlockNum) -> Option<(evm_state::Block, bool)> {
-        if id <= self.get_last_available_evm_block()? {
-            let block = self.blockstore.get_evm_block(id).ok();
+        let get_block_from_bigtable = || {
+            if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
+                let bigtable_block = self
+                    .runtime
+                    .block_on(bigtable_ledger_storage.get_evm_confirmed_full_block(id))
+                    .ok();
 
-            if block.is_none() {
-                if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
-                    let bigtable_block = self
-                        .runtime
-                        .block_on(bigtable_ledger_storage.get_evm_confirmed_full_block(id))
-                        .ok();
-
-                    // bigtable store only confirmed slots
-                    return bigtable_block.map(|b| {
-                        let above_our_chain = self.blockstore.last_root() < b.header.native_chain_slot;
-                        // return confirmed if we have seen it before.
-                        (b, !above_our_chain)
-                    });
-                }
+                // bigtable store only confirmed slots
+                return bigtable_block.map(|b| {
+                    let above_our_chain = self.blockstore.last_root() < b.header.native_chain_slot;
+                    // return confirmed if we have seen it before.
+                    (b, !above_our_chain)
+                });
             }
-            return block;
+            None
+        };
+
+        if let Some(last_evm_block) = self.get_last_available_evm_block() {
+            if id <= last_evm_block {
+                let block = self.blockstore.get_evm_block(id).ok();
+
+                if block.is_none() {
+                    return get_block_from_bigtable();
+                }
+                return block;
+            }
+        }
+        else {
+            return get_block_from_bigtable();
         }
         None
     }


### PR DESCRIPTION
Check that requested evm block number is less or equal to the latest evm block before querying bigtable
