### PR TITLE
Fix(evm-rpc): In block_parse_confirmed_num use last confirmed block

### DIFF
--- a/core/src/evm_rpc_impl/mod.rs
+++ b/core/src/evm_rpc_impl/mod.rs
@@ -149,7 +149,7 @@ fn block_parse_confirmed_num(
         BlockId::BlockHash { .. } => None,
         BlockId::RelativeId(BlockRelId::Earliest) => Some(meta.get_first_available_evm_block()),
         BlockId::RelativeId(BlockRelId::Pending) | BlockId::RelativeId(BlockRelId::Latest) => {
-            Some(meta.get_last_available_evm_block().unwrap_or_else(|| {
+            Some(meta.get_last_confirmed_evm_block().unwrap_or_else(|| {
                 let bank = meta.bank(Some(CommitmentConfig::processed()));
                 let evm = bank.evm_state.read().unwrap();
                 evm.block_number().saturating_sub(1)

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2061,6 +2061,15 @@ impl JsonRpcRequestProcessor {
             .unwrap_or(None)
     }
 
+    ///
+    /// Get last evm block which has respective native chain block rooted
+    pub fn get_last_confirmed_evm_block(&self) -> Option<u64> {
+        self.blockstore
+            .evm_blocks_reverse_iterator().ok()?
+            .find(|(_, header)| self.blockstore.is_root(header.native_chain_slot))
+            .map(|((block_num, _), _)| block_num)
+    }
+
     pub fn get_evm_receipt_by_hash(
         &self,
         hash: evm_state::H256,


### PR DESCRIPTION
Changes:
- Implemented method to get reverse iterator for evm blocks
- Added method to JsonRpcRequestProcessor to find last confirmed evm block
- Changed latest available to latest confirmed block for situations when Pending or Latest block is requested in rpc

