### PR TITLE
Fix(rpc): fix upper bound when requesting evm blocks from bigtable

### DIFF
--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -749,6 +749,12 @@ impl LedgerStorage {
                 };
                 Ok(block)
             })
+            .take_while(|block| {
+                match block {
+                    Ok(block) => block.header.block_number <= last_block,
+                    Err(_) => true,
+                }
+            })
             .collect();
         Ok(deserialized_blocks?)
     }


### PR DESCRIPTION
When range of blocks are requested from bigtable filter out blocks that are out of requested range.