### PR TITLE
Fix(evm-rpc): use chain_id from Bank instead of default one

### DIFF
--- a/core/src/evm_rpc_impl/mod.rs
+++ b/core/src/evm_rpc_impl/mod.rs
@@ -740,6 +740,7 @@ fn call_many(
 
     let estimate_config = evm_state::EvmConfig {
         estimate: true,
+        chain_id: bank.evm_chain_id,
         ..Default::default()
     };
 


### PR DESCRIPTION
When creating context for eth_Call use chain_id from Bank instead of one from EvmConfig::default()
