### PR TITLE
Feature rpc restore block header

### DIFF
--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -100,12 +100,14 @@ pub enum RpcRequest {
     EthTraceCallMany,
     EthTraceReplayTransaction,
     EthTraceReplayBlock,
-    EthRecoverBlockHeader,
 
     /// Velas Account scope
     GetVelasAccountsByOperationalKey,
     GetVelasAccountsByOwnerKey,
     GetVelasRelyingPartiesByOwnerKey,
+
+    /// Debug
+    DebugRecoverBlockHeader,
 }
 
 #[allow(deprecated)]
@@ -189,12 +191,12 @@ impl fmt::Display for RpcRequest {
             RpcRequest::EthTraceCallMany => "trace_callMany",
             RpcRequest::EthTraceReplayTransaction => "trace_replayTransaction",
             RpcRequest::EthTraceReplayBlock => "trace_replayBlockTransactions",
-            RpcRequest::EthRecoverBlockHeader => "eth_recoverBlockHeader",
             RpcRequest::EthEstimateGas => "eth_estimateGas",
             RpcRequest::EthGetLogs => "eth_getLogs",
             RpcRequest::GetVelasAccountsByOperationalKey => "getVelasAccountsByOperationalKey",
             RpcRequest::GetVelasAccountsByOwnerKey => "getVelasAccountsByOwnerKey",
             RpcRequest::GetVelasRelyingPartiesByOwnerKey => "getVelasRelyingPartiesByOwnerKey",
+            RpcRequest::DebugRecoverBlockHeader => "debug_recoverBlockHeader",
         };
 
         write!(f, "{}", method)

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -100,6 +100,7 @@ pub enum RpcRequest {
     EthTraceCallMany,
     EthTraceReplayTransaction,
     EthTraceReplayBlock,
+    EthRecoverBlockHeader,
 
     /// Velas Account scope
     GetVelasAccountsByOperationalKey,
@@ -188,6 +189,7 @@ impl fmt::Display for RpcRequest {
             RpcRequest::EthTraceCallMany => "trace_callMany",
             RpcRequest::EthTraceReplayTransaction => "trace_replayTransaction",
             RpcRequest::EthTraceReplayBlock => "trace_replayBlockTransactions",
+            RpcRequest::EthRecoverBlockHeader => "eth_recoverBlockHeader",
             RpcRequest::EthEstimateGas => "eth_estimateGas",
             RpcRequest::EthGetLogs => "eth_getLogs",
             RpcRequest::GetVelasAccountsByOperationalKey => "getVelasAccountsByOperationalKey",

--- a/core/src/evm_rpc_impl/mod.rs
+++ b/core/src/evm_rpc_impl/mod.rs
@@ -1,8 +1,10 @@
 use std::str::FromStr;
 
 use sha3::{Digest, Keccak256};
+use solana_sdk::account::AccountSharedData;
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::keyed_account::KeyedAccount;
+use solana_sdk::pubkey::Pubkey;
 
 use crate::rpc::JsonRpcRequestProcessor;
 use evm_rpc::error::EvmStateError;
@@ -11,16 +13,19 @@ use evm_rpc::{
     chain_mock::ChainMockERPC,
     error::{into_native_error, BlockNotFound, Error, StateNotFoundForBlock},
     trace::TraceMeta,
-    BlockId, BlockRelId, Bytes, Either, Hex, RPCBlock, RPCLog, RPCLogFilter, RPCReceipt,
+    BlockId, BlockRelId, Bytes, Either, FormatHex, Hex, RPCBlock, RPCLog, RPCLogFilter, RPCReceipt,
     RPCTopicFilter, RPCTransaction,
 };
 use evm_state::{
-    AccountProvider, AccountState, Address, Gas, LogFilter, TransactionAction, H160, H256, U256,
+    AccountProvider, AccountState, Address, BlockHeader, ExecutionResult, Gas, LogFilter,
+    Transaction, TransactionAction, TransactionInReceipt, TransactionReceipt, TransactionSignature,
+    H160, H256, U256,
 };
 use snafu::ensure;
 use snafu::ResultExt;
 use solana_runtime::bank::Bank;
 use std::cell::RefCell;
+use std::convert::TryInto;
 use std::sync::Arc;
 const GAS_PRICE: u64 = 3;
 
@@ -610,6 +615,54 @@ impl BasicERPC for BasicErpcImpl {
         )
     }
 
+    fn recover_block_header(
+        &self,
+        meta: JsonRpcRequestProcessor,
+        txs: Vec<(RPCTransaction, Vec<String>)>,
+        last_hashes: Vec<H256>,
+        block_header: BlockHeader,
+        state_root: H256,
+    ) -> Result<BlockHeader, Error> {
+        let evm_state = meta
+            .evm_state_archive()
+            .ok_or(Error::ArchiveNotSupported)?
+            .new_incomming_for_root(state_root)
+            .ok_or(Error::StateNotFoundForBlock {
+                block: BlockId::Num(Hex(block_header.block_number)),
+            })?;
+
+        let estimate_config = evm_state::EvmConfig {
+            chain_id: meta.bank(None).evm_chain_id,
+            estimate: false,
+            ..Default::default()
+        };
+
+        let last_hashes = last_hashes.try_into().map_err(|_| Error::InvalidParams {})?;
+        let mut executor = evm_state::Executor::with_config(
+            evm_state,
+            evm_state::ChainContext::new(last_hashes),
+            estimate_config,
+        );
+
+        debug!("running evm executor = {:?}", executor);
+        for (tx, meta_keys) in txs {
+            let meta_keys = meta_keys
+                .iter()
+                .map(|s| solana_sdk::pubkey::Pubkey::from_str(s))
+                .collect::<Result<Vec<Pubkey>, _>>()
+                .map_err(|_| Error::InvalidParams {})?;
+            simulate_transaction(&mut executor, tx.clone(), meta_keys)?;
+        }
+        Ok(executor
+            .evm_backend
+            .commit_block(
+                block_header.native_chain_slot,
+                block_header.native_chain_hash,
+            )
+            .state
+            .block)
+    }
+
     fn estimate_gas(
         &self,
         meta: Self::Metadata,
@@ -762,6 +815,144 @@ fn call_many(
             &*bank,
         )?)
     }
+    Ok(result)
+}
+
+fn simulate_transaction(
+    executor: &mut evm_state::Executor,
+    tx: RPCTransaction,
+    meta_keys: Vec<solana_sdk::pubkey::Pubkey>,
+) -> Result<ExecutionResult, Error> {
+    use solana_evm_loader_program::precompiles::*;
+    let caller = tx.from.map(|a| a.0).unwrap_or_default();
+
+    let value = tx.value.map(|a| a.0).unwrap_or_else(|| 0.into());
+    let input = tx.input.map(|a| a.0).unwrap_or_else(Vec::new);
+    let gas_limit = tx.gas.map(|a| a.0).unwrap_or_else(|| u64::MAX.into());
+    // On estimate set gas price to zero, to avoid out of funds errors.
+    let gas_price = u64::MIN.into();
+
+    let nonce = tx
+        .nonce
+        .map(|a| a.0)
+        .unwrap_or_else(|| executor.nonce(caller));
+    let tx_chain_id = executor.chain_id();
+    let tx_hash = tx.hash.map(|a| a.0).unwrap_or_else(H256::random);
+
+    let evm_state_balance = u64::MAX;
+
+    let (user_accounts, action) = if let Some(address) = tx.to {
+        let address = address.0;
+        debug!(
+            "Trying to execute tx = {:?}",
+            (caller, address, value, &input, gas_limit)
+        );
+
+        let mut meta_keys: Vec<_> = meta_keys
+            .into_iter()
+            .map(|pk| {
+                let user_account = RefCell::new(AccountSharedData::new(
+                    u64::MAX,
+                    0,
+                    &solana_sdk::system_program::id(),
+                ));
+                (user_account, pk)
+            })
+            .collect();
+
+        // Shortcut for swap tokens to native, will add solana account to transaction.
+        if address == *ETH_TO_VLX_ADDR {
+            debug!("Found transferToNative transaction");
+            match ETH_TO_VLX_CODE.parse_abi(&input) {
+                Ok(pk) => {
+                    info!("Adding account to meta = {}", pk);
+
+                    let user_account = RefCell::new(AccountSharedData::new(
+                        u64::MAX,
+                        0,
+                        &solana_sdk::system_program::id(),
+                    ));
+                    meta_keys.push((user_account, pk))
+                }
+                Err(e) => {
+                    error!("Error in parsing abi = {}", e);
+                }
+            }
+        }
+
+        (meta_keys, TransactionAction::Call(address))
+    } else {
+        (vec![], TransactionAction::Create)
+    };
+
+    // system transfers always set s = 0x1
+    if Some(Hex(U256::from(0x1))) == tx.s {
+        // check if it native swap, then predeposit, amount, to pass transaction
+        if caller == *ETH_TO_VLX_ADDR {
+            let amount = value + gas_limit * gas_price;
+            executor.deposit(caller, amount)
+        }
+    }
+
+    let user_accounts: Vec<_> = user_accounts
+        .iter()
+        .map(|(user_account, pk)| KeyedAccount::new(pk, false, user_account))
+        .collect();
+
+    let result = executor
+        .transaction_execute_raw(
+            caller,
+            nonce,
+            gas_price,
+            gas_limit,
+            action,
+            input.clone(),
+            value,
+            Some(tx_chain_id),
+            tx_hash,
+            solana_evm_loader_program::precompiles::simulation_entrypoint(
+                executor.support_precompile(),
+                evm_state_balance,
+                &user_accounts,
+            ),
+        )
+        .with_context(|| EvmStateError)?;
+
+    let transaction = Transaction {
+        nonce,
+        gas_price,
+        gas_limit,
+        action,
+        value,
+        signature: TransactionSignature {
+            v: *tx.v.ok_or(Error::InvalidParams {})?,
+            r: tx
+                .r
+                .map(|r| H256::from_hex(&r.format_hex()))
+                .ok_or(Error::InvalidParams {})??,
+            s: tx
+                .s
+                .map(|s| H256::from_hex(&s.format_hex()))
+                .ok_or(Error::InvalidParams {})??,
+        },
+        input,
+    };
+
+    let tx_hashes = executor.evm_backend.get_executed_transactions();
+    assert!(!tx_hashes.contains(&tx_hash));
+
+    let receipt = TransactionReceipt::new(
+        TransactionInReceipt::Signed(transaction),
+        result.used_gas,
+        executor.evm_backend.block_number(),
+        tx_hashes.len() as u64 + 1,
+        result.tx_logs.clone(),
+        (result.exit_reason.clone(), result.exit_data.clone()),
+    );
+    executor
+        .evm_backend
+        .push_transaction_receipt(tx_hash, receipt);
+
     Ok(result)
 }
 

--- a/evm-utils/evm-bridge/src/main.rs
+++ b/evm-utils/evm-bridge/src/main.rs
@@ -706,6 +706,8 @@ impl BasicERPC for BasicErpcProxy {
         )
     }
 
+
+
     fn estimate_gas(
         &self,
         meta: Self::Metadata,

--- a/evm-utils/evm-bridge/src/main.rs
+++ b/evm-utils/evm-bridge/src/main.rs
@@ -706,6 +706,24 @@ impl BasicERPC for BasicErpcProxy {
         )
     }
 
+    fn recover_block_header(
+        &self,
+        meta: Self::Metadata,
+        txs: Vec<(RPCTransaction, Vec<String>)>,
+        last_hashes: Vec<H256>,
+        block_header: BlockHeader,
+        state_root: H256,
+    ) -> EvmResult<BlockHeader> {
+        proxy_evm_rpc!(
+            meta.rpc_client,
+            EthRecoverBlockHeader,
+            txs,
+            last_hashes,
+            block_header,
+            state_root
+        )
+    }
+
 
 
     fn estimate_gas(

--- a/evm-utils/evm-bridge/src/main.rs
+++ b/evm-utils/evm-bridge/src/main.rs
@@ -716,7 +716,7 @@ impl BasicERPC for BasicErpcProxy {
     ) -> EvmResult<BlockHeader> {
         proxy_evm_rpc!(
             meta.rpc_client,
-            EthRecoverBlockHeader,
+            DebugRecoverBlockHeader,
             txs,
             last_hashes,
             block_header,

--- a/evm-utils/evm-rpc/src/error.rs
+++ b/evm-utils/evm-rpc/src/error.rs
@@ -103,7 +103,8 @@ pub enum Error {
     GasPriceTooLow { need: U256 },
     #[snafu(display("Transaction was removed from mempool"))]
     TransactionRemoved {},
-    // InvalidParams {},
+    #[snafu(display("Invalid rpc params"))]
+    InvalidParams {},
     // UnsupportedTrieQuery,
     // NotFound,
     // UnknownSourceMapJump
@@ -195,6 +196,7 @@ impl From<Error> for JRpcError {
             }
             Error::ProxyRpcError { source } => source.clone(),
             Error::WrongChainId { .. } => Self::invalid_params(err.to_string()),
+            Error::InvalidParams {} => Self::invalid_params(err.to_string()),
             Error::EvmStateError { source } => {
                 internal_error_with_details(EVM_STATE_RPC_ERROR, &err, &source)
             }

--- a/evm-utils/evm-rpc/src/lib.rs
+++ b/evm-utils/evm-rpc/src/lib.rs
@@ -12,7 +12,8 @@ use snafu::ResultExt;
 mod serialize;
 use self::error::EvmStateError;
 use evm_state::{
-    Address, ExitSucceed, Gas, LogFilterTopicEntry, LogWithLocation, TransactionInReceipt,
+    Address, BlockHeader, ExitSucceed, Gas, LogFilterTopicEntry, LogWithLocation,
+    TransactionInReceipt,
 };
 
 pub mod error;
@@ -715,6 +716,16 @@ pub mod basic {
             traces: Vec<String>,
             meta_info: Option<TraceMeta>,
         ) -> Result<Vec<trace::TraceResultsWithTransactionHash>, Error>;
+
+        #[rpc(meta, name = "eth_recoverBlockHeader")]
+        fn recover_block_header(
+            &self,
+            meta: Self::Metadata,
+            txs: Vec<(RPCTransaction, Vec<String>)>,
+            last_hashes: Vec<H256>,
+            block_header: BlockHeader,
+            state_root: H256,
+        ) -> Result<BlockHeader, Error>;
 
         #[rpc(meta, name = "eth_estimateGas")]
         fn estimate_gas(

--- a/evm-utils/evm-rpc/src/lib.rs
+++ b/evm-utils/evm-rpc/src/lib.rs
@@ -717,7 +717,7 @@ pub mod basic {
             meta_info: Option<TraceMeta>,
         ) -> Result<Vec<trace::TraceResultsWithTransactionHash>, Error>;
 
-        #[rpc(meta, name = "eth_recoverBlockHeader")]
+        #[rpc(meta, name = "debug_recoverBlockHeader")]
         fn recover_block_header(
             &self,
             meta: Self::Metadata,

--- a/evm-utils/evm-state/src/state.rs
+++ b/evm-utils/evm-state/src/state.rs
@@ -52,7 +52,7 @@ pub struct Incomming {
     pub timestamp: u64,
     pub used_gas: u64,
     pub(crate) state_root: H256,
-    pub(crate) last_block_hash: H256,
+    pub last_block_hash: H256,
     /// Maybe::Nothing indicates removed account
     pub(crate) state_updates: ChangedState,
 


### PR DESCRIPTION
Add RPC that will replay transactions over provided state_root and restore missing fields in block header (transactions, transactions_root, receipts_root, state_root, logs_bloom, gas_used).