### PR TITLE
Update deps and code to support Apple silicon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,12 +676,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.49"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e450b8da92aa6f274e7c6437692f9f2ce6d701fb73bacfcf87897b3f89a4c20e"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 dependencies = [
  "jobserver",
- "num_cpus",
 ]
 
 [[package]]
@@ -1088,7 +1087,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde",
 ]
@@ -2175,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.3"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -2346,7 +2345,7 @@ checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
- "itoa",
+ "itoa 0.4.7",
 ]
 
 [[package]]
@@ -2412,7 +2411,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.7",
  "pin-project-lite",
  "socket2 0.4.1",
  "tokio 1.9.0",
@@ -2423,17 +2422,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
- "futures-util",
+ "http",
  "hyper 0.14.11",
- "log 0.4.14",
- "rustls",
+ "rustls 0.20.2",
  "tokio 1.9.0",
- "tokio-rustls",
- "webpki",
+ "tokio-rustls 0.23.2",
 ]
 
 [[package]]
@@ -2609,6 +2606,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "jemalloc-ctl"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,7 +2730,7 @@ dependencies = [
  "jsonrpc-server-utils",
  "log 0.4.14",
  "net2",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "unicase 2.6.0",
 ]
 
@@ -2742,7 +2745,7 @@ dependencies = [
  "jsonrpc-server-utils",
  "log 0.4.14",
  "parity-tokio-ipc",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "tower-service",
 ]
 
@@ -2756,7 +2759,7 @@ dependencies = [
  "jsonrpc-core",
  "lazy_static 1.4.0",
  "log 0.4.14",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "rand 0.7.3",
  "serde",
 ]
@@ -2790,7 +2793,7 @@ dependencies = [
  "jsonrpc-server-utils",
  "log 0.4.14",
  "parity-ws",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "slab",
 ]
 
@@ -2849,7 +2852,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -2896,6 +2899,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "librocksdb-sys"
@@ -3021,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -3203,9 +3212,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static 1.4.0",
  "libc",
@@ -3380,7 +3389,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 dependencies = [
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -3536,13 +3545,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.4",
- "parking_lot_core 0.8.3",
+ "lock_api 0.4.6",
+ "parking_lot_core 0.8.5",
 ]
 
 [[package]]
@@ -3576,9 +3585,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -4284,12 +4293,16 @@ dependencies = [
 
 [[package]]
 name = "reed-solomon-erasure"
-version = "4.0.2"
-source = "git+https://github.com/velas/reed-solomon-erasure.git?branch=avx-buildfix#4db2f51790ad8470944aaf3850fc054667e17e41"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170bac0d8306941e101df0caaa6518b10bc4232dd36c34f1cb78b8a063024db"
 dependencies = [
  "cc",
  "libc",
+ "libm",
+ "parking_lot 0.11.2",
  "smallvec 1.6.1",
+ "spin 0.9.2",
 ]
 
 [[package]]
@@ -4326,15 +4339,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.4"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.0.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper 0.14.11",
@@ -4348,19 +4362,20 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.2",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.9.0",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.23.2",
  "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -4371,14 +4386,14 @@ checksum = "e9c17925a9027d298a4603d286befe3f9dc0e8ed02523141914eb628798d6e5b"
 
 [[package]]
 name = "ring"
-version = "0.16.12"
+version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
- "lazy_static 1.4.0",
  "libc",
- "spin",
+ "once_cell",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
@@ -4495,8 +4510,29 @@ dependencies = [
  "base64 0.13.0",
  "log 0.4.14",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.0",
+ "webpki 0.21.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
+dependencies = [
+ "log 0.4.14",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -4567,6 +4603,16 @@ name = "sct"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -4713,19 +4759,19 @@ version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -6726,6 +6772,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+
+[[package]]
 name = "spl-associated-token-account"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7225,7 +7277,7 @@ dependencies = [
  "mio 0.7.13",
  "num_cpus",
  "once_cell",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
@@ -7341,9 +7393,20 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls",
+ "rustls 0.19.1",
  "tokio 1.9.0",
- "webpki",
+ "webpki 0.21.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
+dependencies = [
+ "rustls 0.20.2",
+ "tokio 1.9.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -7529,7 +7592,7 @@ dependencies = [
  "prost",
  "prost-derive",
  "tokio 1.9.0",
- "tokio-rustls",
+ "tokio-rustls 0.22.0",
  "tokio-stream",
  "tokio-util 0.6.7",
  "tower",
@@ -7941,7 +8004,7 @@ dependencies = [
  "tempfile",
  "url 2.2.2",
  "winapi 0.3.9",
- "winreg",
+ "winreg 0.7.0",
 ]
 
 [[package]]
@@ -8065,8 +8128,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -8147,12 +8208,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.21.1"
+name = "webpki"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
- "webpki",
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -8244,6 +8315,15 @@ name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,7 +24,7 @@ indicatif = "0.15.0"
 humantime = "2.0.1"
 num-traits = "0.2"
 pretty-hex = "0.2.1"
-reqwest = { version = "0.11.2", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 serde = "1.0.122"
 serde_derive = "1.0.103"
 serde_json = "1.0.56"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,7 +19,7 @@ jsonrpc-core = "18.0.0"
 log = "0.4.11"
 net2 = "0.2.37"
 rayon = "1.5.0"
-reqwest = { version = "0.11.2", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 semver = "0.11.0"
 serde = "1.0.122"
 serde_derive = "1.0.103"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -101,7 +101,7 @@ anyhow = "1"
 [dev-dependencies]
 matches = "0.1.6"
 num_cpus = "1.13.0"
-reqwest = { version = "0.11.2", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 serial_test = "0.4.0"
 symlink = "0.1.0"
 systemstat = "0.1.5"

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1521,6 +1521,7 @@ fn report_target_features() {
         }
     );
 
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "aarch64_apple_darwin")))]
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
         // Validator binaries built on a machine with AVX support will generate invalid opcodes

--- a/crate-features/Cargo.toml
+++ b/crate-features/Cargo.toml
@@ -12,14 +12,14 @@ edition = "2018"
 [dependencies]
 backtrace = { version = "0.3.33", features = ["serialize-serde"] }
 bytes = { version = "0.4.12", features = ["either"] }
-cc = { version = "1.0.45", features = ["jobserver", "num_cpus", "parallel"]}
+cc = { version = "1.0.72", features = ["jobserver", "parallel"]}
 curve25519-dalek = { version = "2" }
 either= { version = "1.5.2" }
 lazy_static = { version = "1.4.0", features = ["spin", "spin_no_std"] }
 libc = { version = "0.2.62", features = ["extra_traits"] }
 rand_chacha = { version = "0.2.2" }
 regex-syntax = { version = "0.6.12" }
-reqwest = { version = "0.11.2", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 serde = { version = "1.0.100", features = ["rc"] }
 ed25519-dalek = { version = "=1.0.1", features = ["serde"] }
 syn_0_15 = { package = "syn", version = "0.15.42", features = ["extra-traits", "fold", "full"] }

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -14,7 +14,7 @@ bzip2 = "0.3.3"
 console = "0.11.3"
 indicatif = "0.15.0"
 log = "0.4.11"
-reqwest = { version = "0.11.2", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 solana-sdk = { path = "../sdk", version = "=1.6.14" }
 solana-runtime = { path = "../runtime", version = "=1.6.14" }
 tar = "0.4.37"

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -30,7 +30,7 @@ prost = "0.8.0"
 rand = "0.7.0"
 rand_chacha = "0.2.2"
 rayon = "1.5.0"
-reed-solomon-erasure = { git = "https://github.com/velas/reed-solomon-erasure.git", branch = "avx-buildfix", features = ["simd-accel"] }
+reed-solomon-erasure = { version = "5.0.1", features = ["simd-accel"] }
 serde = "1.0.122"
 serde_bytes = "0.11.4"
 sha2 = "0.9.2"

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -498,6 +498,7 @@ impl EntrySlice for [Entry] {
     }
 
     fn verify_cpu(&self, start_hash: &Hash) -> EntryVerificationState {
+        #[cfg(not(any(target_arch = "aarch64", target_arch = "aarch64_apple_darwin")))]
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         let (has_avx2, has_avx512) = (
             is_x86_feature_detected!("avx2"),

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.8.3"
 gethostname = "0.2.1"
 lazy_static = "1.4.0"
 log = "0.4.11"
-reqwest = { version = "0.11.2", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 solana-sdk = { path = "../sdk", version = "=1.6.14" }
 
 [dev-dependencies]

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.11"
-reqwest = { version = "0.11.2", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 serde_json = "1.0"
 
 [lib]

--- a/poh-bench/src/main.rs
+++ b/poh-bench/src/main.rs
@@ -84,6 +84,7 @@ fn main() {
             time.as_us() / iterations as u64
         );
 
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         if is_x86_feature_detected!("avx2") && entry::api().is_some() {
             let mut time = Measure::start("time");
             for _ in 0..iterations {
@@ -99,6 +100,7 @@ fn main() {
             );
         }
 
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         if is_x86_feature_detected!("avx512f") && entry::api().is_some() {
             let mut time = Measure::start("time");
             for _ in 0..iterations {

--- a/ramp-tps/Cargo.toml
+++ b/ramp-tps/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/solana-ramp-tps"
 bzip2 = "0.3.3"
 clap = "2.33.1"
 log = "0.4.11"
-reqwest = { version = "0.11.2", default-features = false }
+reqwest = { version = "0.11.10", default-features = false }
 serde = "1.0.122"
 serde_json = "1.0.56"
 serde_yaml = "0.8.13"

--- a/stake-o-matic/Cargo.toml
+++ b/stake-o-matic/Cargo.toml
@@ -12,7 +12,7 @@ version = "1.6.14"
 [dependencies]
 clap = "2.33.0"
 log = "0.4.11"
-reqwest = { version = "0.11.2", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 semver = "0.9.0"
 serde = { version = "1.0.122", features = ["derive"] }
 serde_json = "1.0.62"


### PR DESCRIPTION
#### Problem
`cargo build` does not work on Apple silicon processor.

For example:

```
error[E0658]: use of unstable library feature 'stdsimd'
  --> poh-bench/src/main.rs:87:12
   |
87 |         if is_x86_feature_detected!("avx2") && entry::api().is_some() {
   |            ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information

error:
               is_x86_feature_detected can only be used on x86 and x86_64 targets.
               You can prevent it from being used in other architectures by
               guarding it behind a cfg(target_arch) as follows:

                   #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
                       if is_x86_feature_detected(...) { ... }
                   }

  --> poh-bench/src/main.rs:87:12
   |
87 |         if is_x86_feature_detected!("avx2") && entry::api().is_some() {
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `is_x86_feature_detected` (in Nightly builds, run with -Z macro-backtrace for more info)
```

#### Summary of Changes
- Updated `reqwest` package to update `ring` dependency
- Added conditional compilation flags for hardware-specific code segments
- Cargo.lock has been minimally affected
- https://github.com/velas/reed-solomon-erasure/tree/avx-buildfix has been switched to upstream, because it contains the fix (we can delete our fork)

Fixes #
