### PR TITLE
feature(evm_loader): add more precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "eip-152"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1ef6436c81c0cc3c2b0df95f77ad25d7a721763b3b2ea385d21b6dda4a84af"
+dependencies = [
+ "arrayref",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,7 +1576,7 @@ version = "3.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2170fc0efee383079a8bdd05d6ea2a184d2a0f07a1c1dcabdb2fd5e9f24bc36c"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.3",
  "num-traits",
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -3108,6 +3117,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "lazycell"
@@ -3484,6 +3496,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+dependencies = [
+ "num-bigint 0.1.44",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.4.6",
+ "rustc-serialize",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,6 +3548,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg 1.1.0",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4957,6 +5004,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6253,11 +6306,13 @@ dependencies = [
  "borsh",
  "byteorder",
  "crc32fast",
+ "eip-152",
  "ethabi",
  "evm-state",
  "hex",
  "hex-literal",
  "log 0.4.17",
+ "num",
  "num-derive",
  "num-traits",
  "once_cell",
@@ -6273,6 +6328,7 @@ dependencies = [
  "solana-logger 1.9.29",
  "solana-program-runtime",
  "solana-sdk",
+ "substrate-bn",
 ]
 
 [[package]]
@@ -7759,6 +7815,18 @@ dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
  "syn 1.0.99",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "git+https://github.com/paritytech/bn.git#63f8c587356a67b33c7396af98e065b66fca5dda"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.5",
+ "rustc-hex",
 ]
 
 [[package]]

--- a/evm-utils/evm-state/src/executor.rs
+++ b/evm-utils/evm-state/src/executor.rs
@@ -84,6 +84,26 @@ impl<'precompile> PrecompileSet for OwnedPrecompile<'precompile> {
     }
 }
 
+impl<'precompile> std::ops::Deref for OwnedPrecompile<'precompile> {
+    type Target = BTreeMap<
+    H160,
+    Box<
+        dyn Fn(
+                &[u8],
+                Option<u64>,
+                Option<CallScheme>,
+                &Context,
+                bool,
+            ) -> Result<(PrecompileOutput, u64, LogEntry), PrecompileFailure>
+            + 'precompile,
+    >,
+>;
+    
+    fn deref(&self) -> &Self::Target {
+        &self.precompiles
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ExecutionResult {
     pub exit_reason: evm::ExitReason,

--- a/evm-utils/evm-state/src/executor.rs
+++ b/evm-utils/evm-state/src/executor.rs
@@ -60,7 +60,7 @@ impl<'precompile> PrecompileSet for OwnedPrecompile<'precompile> {
     fn execute(&self, handle: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
         let address = handle.code_address();
 
-        self.precompiles.get(&address).map(|precompile| {
+        self.get(&address).map(|precompile| {
             let input = handle.input();
             let gas_limit = handle.gas_limit();
             let call_scheme = handle.call_scheme();
@@ -80,7 +80,7 @@ impl<'precompile> PrecompileSet for OwnedPrecompile<'precompile> {
         })
     }
     fn is_precompile(&self, address: H160) -> bool {
-        self.precompiles.contains_key(&address)
+        self.contains_key(&address)
     }
 }
 

--- a/evm-utils/programs/evm_loader/Cargo.toml
+++ b/evm-utils/programs/evm_loader/Cargo.toml
@@ -6,10 +6,6 @@ authors = ["Vladimir Motylenko <vld@stegos.com>"]
 license = "Apache-2.0"
 edition = "2021"
 
-[features]
-default = []
-pricefix = []
-
 [dependencies]
 log = "0.4.8"
 solana-logger = { path = "../../../logger", version = "1.9.13" }

--- a/evm-utils/programs/evm_loader/Cargo.toml
+++ b/evm-utils/programs/evm_loader/Cargo.toml
@@ -28,6 +28,10 @@ sha2 = "0.9.4"
 ripemd160 = "0.9.1"
 num-derive = "0.3"
 num-traits = "0.2"
+num = { version = "0.1", default-features = false, features = ["bigint"] }
+substrate-bn = { git = "https://github.com/paritytech/bn.git", default-features = false }
+byteorder = "1.4.3"
+eip-152 = "0.1.0"
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/evm-utils/programs/evm_loader/Cargo.toml
+++ b/evm-utils/programs/evm_loader/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 description = "Solana EVM loader"
 authors = ["Vladimir Motylenko <vld@stegos.com>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
+
+[features]
+default = []
+pricefix = []
 
 [dependencies]
 log = "0.4.8"

--- a/evm-utils/programs/evm_loader/src/precompiles/compatibility.rs
+++ b/evm-utils/programs/evm_loader/src/precompiles/compatibility.rs
@@ -63,10 +63,15 @@ impl Precompile for EcRecover {
             .expect("Serialization of static data should be determenistic and never fail.")
     }
 
+    #[cfg(not(feature = "pricefix"))]
     fn price(source: &[u8]) -> u64 {
-        // FIXME: price == 3000
-        // Ref.: https://ethereum.github.io/yellowpaper/paper.pdf p.21 (204)
         60 + 12 * words(source, 32)
+    }
+
+    #[cfg(feature = "pricefix")]
+    fn price(_source: &[u8]) -> u64 {
+        // Ref.: https://ethereum.github.io/yellowpaper/paper.pdf p.21 (204)
+        3000
     }
 
     fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
@@ -138,12 +143,17 @@ impl Precompile for Ripemd160 {
             .expect("Serialization of static data should be determenistic and never fail.")
     }
 
+    #[cfg(not(feature = "pricefix"))]
     fn price(source: &[u8]) -> u64 {
-        // FIXME: price == 600 + 120 * words(source, 32)
-        // Ref.: https://ethereum.github.io/yellowpaper/paper.pdf p.22 (219)
         60 + 12 * words(source, 32)
     }
 
+    #[cfg(feature = "pricefix")]
+    fn price(source: &[u8]) -> u64 {
+        // Ref.: https://ethereum.github.io/yellowpaper/paper.pdf p.22 (219)
+        600 + 120 * words(source, 32)
+    }
+ 
     fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
         use ripemd160::{Digest, Ripemd160};
         let mut hasher = Ripemd160::new();

--- a/evm-utils/programs/evm_loader/src/precompiles/compatibility.rs
+++ b/evm-utils/programs/evm_loader/src/precompiles/compatibility.rs
@@ -153,7 +153,7 @@ impl Precompile for Ripemd160 {
         // Ref.: https://ethereum.github.io/yellowpaper/paper.pdf p.22 (219)
         600 + 120 * words(source, 32)
     }
- 
+
     fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
         use ripemd160::{Digest, Ripemd160};
         let mut hasher = Ripemd160::new();

--- a/evm-utils/programs/evm_loader/src/precompiles/compatibility.rs
+++ b/evm-utils/programs/evm_loader/src/precompiles/compatibility.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
 use num::{BigUint, One, Zero};
 
+// Deprecated precompiles differ in price calculations
 mod deprecated {
     use super::*;
 

--- a/evm-utils/programs/evm_loader/src/precompiles/compatibility.rs
+++ b/evm-utils/programs/evm_loader/src/precompiles/compatibility.rs
@@ -1,9 +1,15 @@
 use super::{BuiltinEval, CallResult, PrecompileContext, Result};
-use evm_state::{executor::PrecompileOutput, TransactionSignature, H160, H256};
+use crate::precompiles::PrecompileErrors;
+use evm_state::{executor::PrecompileOutput, TransactionSignature, H160, H256, U256};
 
+use std::cmp::{max, min};
 use std::collections::HashMap;
+use std::convert::TryInto;
+use std::io::{self, Cursor, Read};
 use std::str::FromStr;
-const WORD_LEN: usize = 32;
+
+use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
+use num::{BigUint, One, Zero};
 
 #[derive(Debug)]
 pub struct Identity;
@@ -34,7 +40,8 @@ pub struct Blake2F;
 
 trait Precompile {
     fn address() -> H160;
-    fn pricer() -> Pricer;
+
+    fn price(source: &[u8]) -> u64;
 
     fn implementation(source: &[u8], cx: PrecompileContext) -> Result<Vec<u8>>;
 
@@ -55,9 +62,13 @@ impl Precompile for EcRecover {
         H160::from_str("0000000000000000000000000000000000000001")
             .expect("Serialization of static data should be determenistic and never fail.")
     }
-    fn pricer() -> Pricer {
-        Pricer::Linear { base: 60, word: 12 }
+
+    fn price(source: &[u8]) -> u64 {
+        // FIXME: price == 3000
+        // Ref.: https://ethereum.github.io/yellowpaper/paper.pdf p.21 (204)
+        60 + 12 * words(source, 32)
     }
+
     fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
         use evm_state::secp256k1::{Message, SECP256K1};
         use evm_state::transactions::addr_from_public_key;
@@ -103,9 +114,11 @@ impl Precompile for Sha256 {
         H160::from_str("0000000000000000000000000000000000000002")
             .expect("Serialization of static data should be determenistic and never fail.")
     }
-    fn pricer() -> Pricer {
-        Pricer::Linear { base: 60, word: 12 }
+
+    fn price(source: &[u8]) -> u64 {
+        60 + 12 * words(source, 32)
     }
+
     fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
@@ -124,9 +137,13 @@ impl Precompile for Ripemd160 {
         H160::from_str("0000000000000000000000000000000000000003")
             .expect("Serialization of static data should be determenistic and never fail.")
     }
-    fn pricer() -> Pricer {
-        Pricer::Linear { base: 60, word: 12 }
+
+    fn price(source: &[u8]) -> u64 {
+        // FIXME: price == 600 + 120 * words(source, 32)
+        // Ref.: https://ethereum.github.io/yellowpaper/paper.pdf p.22 (219)
+        60 + 12 * words(source, 32)
     }
+
     fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
         use ripemd160::{Digest, Ripemd160};
         let mut hasher = Ripemd160::new();
@@ -147,26 +164,521 @@ impl Precompile for Identity {
         H160::from_str("0000000000000000000000000000000000000004")
             .expect("Serialization of static data should be determenistic and never fail.")
     }
-    fn pricer() -> Pricer {
-        Pricer::Linear { base: 15, word: 3 }
+
+    fn price(source: &[u8]) -> u64 {
+        15 + 3 * words(source, 32)
     }
+
     fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
         Ok(source.to_vec())
     }
 }
 
-enum Pricer {
-    Linear { base: u64, word: u64 },
-}
-impl Pricer {
-    fn calculate_price(&self, source: &[u8]) -> u64 {
-        match self {
-            Pricer::Linear { base, word } => {
-                let num_words = (source.len() / WORD_LEN) as u64;
-                base + word * num_words
+impl Precompile for Modexp {
+    fn address() -> H160 {
+        H160::from_str("0000000000000000000000000000000000000005")
+            .expect("Serialization of static data should be determenistic and never fail.")
+    }
+
+    fn price(source: &[u8]) -> u64 {
+        // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-198.md
+        // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2565.md
+        const DIVISOR: u64 = 20;
+
+        fn parse_input(input: &[u8]) -> (U256, U256, U256, U256) {
+            let mut reader = input.chain(io::repeat(0));
+            let mut buf = [0; 32];
+
+            // read lengths as U256 here for accurate gas calculation.
+            let mut read_len = || {
+                reader
+                    .read_exact(&mut buf[..])
+                    .expect("reading from zero-extended memory cannot fail; qed");
+                U256::from_big_endian(&buf[..])
+            };
+            let base_len_u256 = read_len();
+            let exp_len_u256 = read_len();
+            let mod_len_u256 = read_len();
+
+            let (base_len, exp_len) = (base_len_u256.low_u64(), exp_len_u256.low_u64());
+
+            // read fist 32-byte word of the exponent.
+            let exp_low = if base_len + 96 >= input.len() as u64 {
+                U256::zero()
+            } else {
+                buf.iter_mut().for_each(|b| *b = 0);
+                let mut reader = input[(96 + base_len as usize)..].chain(io::repeat(0));
+                let len = min(exp_len, 32) as usize;
+                reader
+                    .read_exact(&mut buf[(32 - len)..])
+                    .expect("reading from zero-extended memory cannot fail; qed");
+                U256::from_big_endian(&buf[..])
+            };
+
+            (base_len_u256, exp_len_u256, exp_low, mod_len_u256)
+        }
+
+        fn check_input_boundaries(base_len: &U256, exp_len: &U256, mod_len: &U256) -> Option<u64> {
+            if mod_len.is_zero() && base_len.is_zero() {
+                return Some(0);
+            }
+
+            let max_len = U256::from(u32::max_value() / 2);
+            if base_len > &max_len || mod_len > &max_len || exp_len > &max_len {
+                return Some(u64::max_value());
+            }
+            None
+        }
+
+        fn adjusted_exp_len(len: u64, exp_low: U256) -> u64 {
+            let bit_index = if exp_low.is_zero() {
+                0
+            } else {
+                (255 - exp_low.leading_zeros()) as u64
+            };
+            if len <= 32 {
+                bit_index
+            } else {
+                8 * (len - 32) + bit_index
             }
         }
+
+        fn mult_complexity(x: u64) -> u64 {
+            match x {
+                x if x <= 64 => x * x,
+                x if x <= 1024 => (x * x) / 4 + 96 * x - 3072,
+                x => (x * x) / 16 + 480 * x - 199_680,
+            }
+        }
+
+        let (base_len, exp_len, exp_low, mod_len) = parse_input(source);
+
+        if let Some(cost) = check_input_boundaries(&base_len, &exp_len, &mod_len) {
+            return cost;
+        }
+
+        let (base_len, exp_len, mod_len) =
+            (base_len.low_u64(), exp_len.low_u64(), mod_len.low_u64());
+
+        let adjusted_exp_len = adjusted_exp_len(exp_len, exp_low);
+
+        let m = max(mod_len, base_len);
+        let (gas, overflow) = mult_complexity(m).overflowing_mul(max(adjusted_exp_len, 1));
+        if overflow {
+            return u64::max_value();
+        }
+
+        gas / DIVISOR
     }
+
+    fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
+        // calculate modexp: left-to-right binary exponentiation to keep multiplicands lower
+        fn modexp(mut base: BigUint, exp: Vec<u8>, modulus: BigUint) -> BigUint {
+            const BITS_PER_DIGIT: usize = 8;
+
+            // n^m % 0 || n^m % 1
+            if modulus <= BigUint::one() {
+                return BigUint::zero();
+            }
+
+            // normalize exponent
+            let mut exp = exp.into_iter().skip_while(|d| *d == 0).peekable();
+
+            // n^0 % m
+            if exp.peek().is_none() {
+                return BigUint::one();
+            }
+
+            // 0^n % m, n > 0
+            if base.is_zero() {
+                return BigUint::zero();
+            }
+
+            base %= &modulus;
+
+            // Fast path for base divisible by modulus.
+            if base.is_zero() {
+                return BigUint::zero();
+            }
+
+            // Left-to-right binary exponentiation (Handbook of Applied Cryptography - Algorithm 14.79).
+            // http://www.cacr.math.uwaterloo.ca/hac/about/chap14.pdf
+            let mut result = BigUint::one();
+
+            for digit in exp {
+                let mut mask = 1 << (BITS_PER_DIGIT - 1);
+
+                for _ in 0..BITS_PER_DIGIT {
+                    result = &result * &result % &modulus;
+
+                    if digit & mask > 0 {
+                        result = result * &base % &modulus;
+                    }
+
+                    mask >>= 1;
+                }
+            }
+
+            result
+        }
+
+        let mut reader = source.chain(io::repeat(0));
+        let mut buf = [0; 32];
+
+        // read lengths as usize.
+        // ignoring the first 24 bytes might technically lead us to fall out of consensus,
+        // but so would running out of addressable memory!
+        let mut read_len = |reader: &mut io::Chain<&[u8], io::Repeat>| {
+            reader
+                .read_exact(&mut buf[..])
+                .expect("reading from zero-extended memory cannot fail; qed");
+            let mut len_bytes = [0u8; 8];
+            len_bytes.copy_from_slice(&buf[24..]);
+            u64::from_be_bytes(len_bytes) as usize
+        };
+
+        let base_len = read_len(&mut reader);
+        let exp_len = read_len(&mut reader);
+        let mod_len = read_len(&mut reader);
+
+        // Gas formula allows arbitrary large exp_len when base and modulus are empty, so we need to handle empty base first.
+        let r = if base_len == 0 && mod_len == 0 {
+            BigUint::zero()
+        } else {
+            // read the numbers themselves.
+            let mut buf = vec![0; max(mod_len, max(base_len, exp_len))];
+            let mut read_num = |reader: &mut io::Chain<&[u8], io::Repeat>, len: usize| {
+                reader
+                    .read_exact(&mut buf[..len])
+                    .expect("reading from zero-extended memory cannot fail; qed");
+                BigUint::from_bytes_be(&buf[..len])
+            };
+
+            let base = read_num(&mut reader, base_len);
+
+            let mut exp_buf = vec![0; exp_len];
+            reader
+                .read_exact(&mut exp_buf[..exp_len])
+                .expect("reading from zero-extended memory cannot fail; qed");
+
+            let modulus = read_num(&mut reader, mod_len);
+
+            modexp(base, exp_buf, modulus)
+        };
+
+        // write output to given memory, left padded and same length as the modulus.
+        let bytes = r.to_bytes_be();
+
+        let mut output = vec![0u8; mod_len];
+
+        // always true except in the case of zero-length modulus, which leads to
+        // output of length and value 1.
+        if bytes.len() <= mod_len {
+            let res_start = mod_len - bytes.len();
+            output.resize(res_start, 0);
+            output.extend_from_slice(&bytes);
+        }
+
+        Ok(output)
+    }
+}
+
+impl Precompile for Bn128Add {
+    fn address() -> H160 {
+        H160::from_str("0000000000000000000000000000000000000006")
+            .expect("Serialization of static data should be determenistic and never fail.")
+    }
+
+    fn price(_source: &[u8]) -> u64 {
+        150
+    }
+
+    fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
+        use substrate_bn::AffineG1;
+
+        let mut padded_input = source.chain(io::repeat(0));
+        let p1 = read_point(&mut padded_input)?;
+        let p2 = read_point(&mut padded_input)?;
+
+        let mut output = Vec::from([0u8; 64]);
+        if let Some(sum) = AffineG1::from_jacobian(p1 + p2) {
+            // point not at infinity
+            sum.x()
+                .to_big_endian(&mut output[0..32])
+                .expect("Cannot fail since 0..32 is 32-byte length");
+            sum.y()
+                .to_big_endian(&mut output[32..64])
+                .expect("Cannot fail since 32..64 is 32-byte length");
+        }
+        Ok(output)
+    }
+}
+
+impl Precompile for Bn128Mul {
+    fn address() -> H160 {
+        H160::from_str("0000000000000000000000000000000000000007")
+            .expect("Serialization of static data should be determenistic and never fail.")
+    }
+
+    fn price(_source: &[u8]) -> u64 {
+        6_000
+    }
+
+    fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
+        use substrate_bn::AffineG1;
+
+        let mut padded_input = source.chain(io::repeat(0));
+        let p = read_point(&mut padded_input)?;
+        let fr = read_fr(&mut padded_input)?;
+
+        let mut write_buf = Vec::from([0u8; 64]);
+        if let Some(sum) = AffineG1::from_jacobian(p * fr) {
+            // point not at infinity
+            sum.x()
+                .to_big_endian(&mut write_buf[0..32])
+                .expect("Cannot fail since 0..32 is 32-byte length");
+            sum.y()
+                .to_big_endian(&mut write_buf[32..64])
+                .expect("Cannot fail since 32..64 is 32-byte length");
+        }
+
+        Ok(write_buf)
+    }
+}
+
+impl Precompile for Bn128Pairing {
+    fn address() -> H160 {
+        H160::from_str("0000000000000000000000000000000000000008")
+            .expect("Serialization of static data should be determenistic and never fail.")
+    }
+
+    fn price(source: &[u8]) -> u64 {
+        45_000 + 34_000 * words(source, 192)
+    }
+
+    fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
+        fn execute_with_error(source: &[u8]) -> Result<Vec<u8>> {
+            use substrate_bn::{pairing, AffineG1, AffineG2, Fq, Fq2, Group, Gt, G1, G2};
+
+            let ret_val =
+                if source.is_empty() {
+                    U256::one()
+                } else {
+                    // (a, b_a, b_b - each 64-byte affine coordinates)
+                    let elements = source.len() / 192;
+                    let mut vals = Vec::new();
+                    for idx in 0..elements {
+                        let a_x =
+                            Fq::from_slice(&source[idx * 192..idx * 192 + 32]).map_err(|_| {
+                                PrecompileErrors::ParseCoordinateError {
+                                    message: "Invalid a argument x coordinate".into(),
+                                }
+                            })?;
+
+                        let a_y = Fq::from_slice(&source[idx * 192 + 32..idx * 192 + 64]).map_err(
+                            |_| PrecompileErrors::ParseCoordinateError {
+                                message: "Invalid a argument y coordinate".into(),
+                            },
+                        )?;
+
+                        let b_a_y = Fq::from_slice(&source[idx * 192 + 64..idx * 192 + 96])
+                            .map_err(|_| PrecompileErrors::ParseCoordinateError {
+                                message: "Invalid b argument imaginary coeff x coordinate".into(),
+                            })?;
+
+                        let b_a_x = Fq::from_slice(&source[idx * 192 + 96..idx * 192 + 128])
+                            .map_err(|_| PrecompileErrors::ParseCoordinateError {
+                                message: "Invalid b argument imaginary coeff y coordinate".into(),
+                            })?;
+
+                        let b_b_y = Fq::from_slice(&source[idx * 192 + 128..idx * 192 + 160])
+                            .map_err(|_| PrecompileErrors::ParseCoordinateError {
+                                message: "Invalid b argument real coeff x coordinate".into(),
+                            })?;
+
+                        let b_b_x = Fq::from_slice(&source[idx * 192 + 160..idx * 192 + 192])
+                            .map_err(|_| PrecompileErrors::ParseCoordinateError {
+                                message: "Invalid b argument real coeff y coordinate".into(),
+                            })?;
+
+                        let b_a = Fq2::new(b_a_x, b_a_y);
+                        let b_b = Fq2::new(b_b_x, b_b_y);
+                        let b = if b_a.is_zero() && b_b.is_zero() {
+                            G2::zero()
+                        } else {
+                            G2::from(AffineG2::new(b_a, b_b).map_err(|_| {
+                                PrecompileErrors::ParseCoordinateError {
+                                    message: "Invalid b argument - not on curve".into(),
+                                }
+                            })?)
+                        };
+                        let a = if a_x.is_zero() && a_y.is_zero() {
+                            G1::zero()
+                        } else {
+                            G1::from(AffineG1::new(a_x, a_y).map_err(|_| {
+                                PrecompileErrors::ParseCoordinateError {
+                                    message: "Invalid a argument - not on curve".into(),
+                                }
+                            })?)
+                        };
+                        vals.push((a, b));
+                    }
+
+                    let mul = vals
+                        .into_iter()
+                        .fold(Gt::one(), |s, (a, b)| s * pairing(a, b));
+
+                    if mul == Gt::one() {
+                        U256::one()
+                    } else {
+                        U256::zero()
+                    }
+                };
+
+            let mut result = vec![0u8; 32];
+
+            ret_val.to_big_endian(&mut result);
+
+            let max = min(result.len(), source.len());
+
+            result[0..max].copy_from_slice(&source[..max]);
+
+            Ok(result)
+        }
+
+        if source.len() % 192 != 0 {
+            return Err(PrecompileErrors::ParsePointError {
+                message: "Invalid input length, must be multiple of 192 (3 * (32*2))".into(),
+            });
+        }
+
+        execute_with_error(source)
+    }
+}
+
+impl Precompile for Blake2F {
+    fn address() -> H160 {
+        H160::from_str("0000000000000000000000000000000000000009")
+            .expect("Serialization of static data should be determenistic and never fail.")
+    }
+
+    fn price(source: &[u8]) -> u64 {
+        // FIXME: set correct value
+        const GAS_PER_ROUND: u64 = 1;
+
+        const FOUR: usize = std::mem::size_of::<u32>();
+
+        if source.len() < FOUR {
+            return 0;
+        }
+
+        let (rounds, _) = source.split_at(FOUR);
+        let rounds = u32::from_be_bytes(rounds.try_into().unwrap_or([0u8; 4]));
+        GAS_PER_ROUND * rounds as u64
+    }
+
+    fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
+        const BLAKE2_F_ARG_LEN: usize = 213;
+        const PROOF: &str = "Checked the length of the input above; qed";
+
+        if source.len() != BLAKE2_F_ARG_LEN {
+            return Err(PrecompileErrors::BadInputLength {
+                length: source.len(),
+            });
+        }
+
+        let mut cursor = Cursor::new(source);
+        let rounds = cursor.read_u32::<BigEndian>().expect(PROOF);
+
+        // state vector, h
+        let mut h = [0u64; 8];
+        for state_word in &mut h {
+            *state_word = cursor.read_u64::<LittleEndian>().expect(PROOF);
+        }
+
+        // message block vector, m
+        let mut m = [0u64; 16];
+        for msg_word in &mut m {
+            *msg_word = cursor.read_u64::<LittleEndian>().expect(PROOF);
+        }
+
+        // 2w-bit offset counter, t
+        let t = [
+            cursor.read_u64::<LittleEndian>().expect(PROOF),
+            cursor.read_u64::<LittleEndian>().expect(PROOF),
+        ];
+
+        // final block indicator flag, "f"
+        let f = match source.last() {
+            Some(1) => true,
+            Some(0) => false,
+            _ => {
+                return Err(PrecompileErrors::IncorrectBlockIndicator);
+            }
+        };
+
+        eip_152::compress(&mut h, m, t, f, rounds as usize);
+
+        let mut output = vec![0u8; 64];
+
+        let mut output_buf = [0u8; 8 * std::mem::size_of::<u64>()];
+        for (i, state_word) in h.iter().enumerate() {
+            output_buf[i * 8..(i + 1) * 8].copy_from_slice(&state_word.to_le_bytes());
+        }
+
+        let max = min(output.len(), output_buf.len());
+        output[0..max].copy_from_slice(&output_buf[..max]);
+
+        Ok(output)
+    }
+}
+
+fn words(source: &[u8], word_len: usize) -> u64 {
+    (source.len() / word_len) as u64
+}
+
+fn read_fr(
+    reader: &mut io::Chain<&[u8], io::Repeat>,
+) -> Result<substrate_bn::Fr, PrecompileErrors> {
+    let mut buf = [0u8; 32];
+
+    reader
+        .read_exact(&mut buf[..])
+        .expect("reading from zero-extended memory cannot fail; qed");
+    substrate_bn::Fr::from_slice(&buf[0..32]).map_err(|_| PrecompileErrors::ParsePointError {
+        message: "Invalid field element".into(),
+    })
+}
+
+fn read_point(
+    reader: &mut io::Chain<&[u8], io::Repeat>,
+) -> Result<substrate_bn::G1, PrecompileErrors> {
+    use substrate_bn::{AffineG1, Fq, Group, G1};
+
+    let mut buf = [0u8; 32];
+
+    reader
+        .read_exact(&mut buf[..])
+        .expect("reading from zero-extended memory cannot fail; qed");
+    let px = Fq::from_slice(&buf[0..32]).map_err(|_| PrecompileErrors::ParsePointError {
+        message: "Invalid point x coordinate".into(),
+    })?;
+
+    reader
+        .read_exact(&mut buf[..])
+        .expect("reading from zero-extended memory cannot fail; qed");
+    let py = Fq::from_slice(&buf[0..32]).map_err(|_| PrecompileErrors::ParsePointError {
+        message: "Invalid point y coordinate".into(),
+    })?;
+    Ok(if px == Fq::zero() && py == Fq::zero() {
+        G1::zero()
+    } else {
+        AffineG1::new(px, py)
+            .map_err(|_| PrecompileErrors::ParsePointError {
+                message: "Invalid curve point".into(),
+            })?
+            .into()
+    })
 }
 
 pub fn extend_precompile_map(map: &mut HashMap<H160, BuiltinEval>) {
@@ -174,10 +686,15 @@ pub fn extend_precompile_map(map: &mut HashMap<H160, BuiltinEval>) {
     Sha256::insert_to_map(map);
     Ripemd160::insert_to_map(map);
     EcRecover::insert_to_map(map);
+    Modexp::insert_to_map(map);
+    Bn128Add::insert_to_map(map);
+    Bn128Mul::insert_to_map(map);
+    Bn128Pairing::insert_to_map(map);
+    Blake2F::insert_to_map(map);
 }
 
 fn execute_precompile<T: Precompile>(source: &[u8], cx: PrecompileContext) -> CallResult {
-    let gas_used = T::pricer().calculate_price(source);
+    let gas_used = T::price(source);
     let bytes = T::implementation(source, cx)?;
     Ok((
         PrecompileOutput {
@@ -188,59 +705,3 @@ fn execute_precompile<T: Precompile>(source: &[u8], cx: PrecompileContext) -> Ca
         vec![],
     ))
 }
-
-//TODO:
-// "0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": "0x00", "pricing": { "modexp": { "divisor": 20 } } } },
-// "0000000000000000000000000000000000000006": {
-// 	"builtin": {
-// 		"name": "alt_bn128_add",
-// 		"pricing": {
-// 			"0": {
-// 				"price": { "alt_bn128_const_operations": { "price": 500 }}
-// 			},
-// 			"0": {
-// 				"info": "EIP 1108 transition",
-// 				"price": { "alt_bn128_const_operations": { "price": 150 }}
-// 			}
-// 		}
-// 	}
-// },
-// "0000000000000000000000000000000000000007": {
-// 	"builtin": {
-// 		"name": "alt_bn128_mul",
-// 		"pricing": {
-// 			"0": {
-// 				"price": { "alt_bn128_const_operations": { "price": 40000 }}
-// 			},
-// 			"0": {
-// 				"info": "EIP 1108 transition",
-// 				"price": { "alt_bn128_const_operations": { "price": 6000 }}
-// 			}
-// 		}
-// 	}
-// },
-// "0000000000000000000000000000000000000008": {
-// 	"builtin": {
-// 		"name": "alt_bn128_pairing",
-// 		"pricing": {
-// 			"0": {
-// 				"price": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 }}
-// 			},
-// 			"0": {
-// 				"info": "EIP 1108 transition",
-// 				"price": { "alt_bn128_pairing": { "base": 45000, "pair": 34000 }}
-// 			}
-// 		}
-// 	}
-// },
-// "0000000000000000000000000000000000000009": {
-// 	"builtin": {
-// 		"name": "blake2_f",
-// 		"activate_at": "0x00",
-// 		"pricing": {
-// 			"blake2_f": {
-// 				"gas_per_round": 1
-// 			}
-// 		}
-// 	}
-// }

--- a/evm-utils/programs/evm_loader/src/precompiles/compatibility.rs
+++ b/evm-utils/programs/evm_loader/src/precompiles/compatibility.rs
@@ -63,16 +63,15 @@ impl Precompile for EcRecover {
             .expect("Serialization of static data should be determenistic and never fail.")
     }
 
-    #[cfg(not(feature = "pricefix"))]
     fn price(source: &[u8]) -> u64 {
         60 + 12 * words(source, 32)
     }
 
-    #[cfg(feature = "pricefix")]
-    fn price(_source: &[u8]) -> u64 {
-        // Ref.: https://ethereum.github.io/yellowpaper/paper.pdf p.21 (204)
-        3000
-    }
+    // TODO: implement as a feature
+    // fn price(_source: &[u8]) -> u64 {
+    //     // Ref.: https://ethereum.github.io/yellowpaper/paper.pdf p.21 (204)
+    //     3000
+    // }
 
     fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
         use evm_state::secp256k1::{Message, SECP256K1};
@@ -143,16 +142,15 @@ impl Precompile for Ripemd160 {
             .expect("Serialization of static data should be determenistic and never fail.")
     }
 
-    #[cfg(not(feature = "pricefix"))]
     fn price(source: &[u8]) -> u64 {
         60 + 12 * words(source, 32)
     }
 
-    #[cfg(feature = "pricefix")]
-    fn price(source: &[u8]) -> u64 {
-        // Ref.: https://ethereum.github.io/yellowpaper/paper.pdf p.22 (219)
-        600 + 120 * words(source, 32)
-    }
+    // TODO: implement as a feature
+    // fn price(source: &[u8]) -> u64 {
+    //     // Ref.: https://ethereum.github.io/yellowpaper/paper.pdf p.22 (219)
+    //     600 + 120 * words(source, 32)
+    // }
 
     fn implementation(source: &[u8], _cx: PrecompileContext) -> Result<Vec<u8>> {
         use ripemd160::{Digest, Ripemd160};
@@ -696,11 +694,12 @@ pub fn extend_precompile_map(map: &mut HashMap<H160, BuiltinEval>) {
     Sha256::insert_to_map(map);
     Ripemd160::insert_to_map(map);
     EcRecover::insert_to_map(map);
-    Modexp::insert_to_map(map);
-    Bn128Add::insert_to_map(map);
-    Bn128Mul::insert_to_map(map);
-    Bn128Pairing::insert_to_map(map);
-    Blake2F::insert_to_map(map);
+    // TODO: implement as a new feature
+    // Modexp::insert_to_map(map);
+    // Bn128Add::insert_to_map(map);
+    // Bn128Mul::insert_to_map(map);
+    // Bn128Pairing::insert_to_map(map);
+    // Blake2F::insert_to_map(map);
 }
 
 fn execute_precompile<T: Precompile>(source: &[u8], cx: PrecompileContext) -> CallResult {

--- a/evm-utils/programs/evm_loader/src/precompiles/errors.rs
+++ b/evm-utils/programs/evm_loader/src/precompiles/errors.rs
@@ -58,6 +58,18 @@ pub enum PrecompileErrors {
 
     #[snafu(display("Failed to serialize log = {:?}", error))]
     LogSerializeError { error: bincode::Error },
+
+    #[snafu(display("Cannot parse point: {}", message))]
+    ParsePointError { message: String },
+
+    #[snafu(display("Cannot parse coordinate: {}", message))]
+    ParseCoordinateError { message: String },
+
+    #[snafu(display("Bad input length: {}", length))]
+    BadInputLength { length: usize },
+
+    #[snafu(display("Incorrect final block indicator flag"))]
+    IncorrectBlockIndicator,
 }
 
 impl From<PrecompileErrors> for ExitError {

--- a/evm-utils/programs/evm_loader/src/precompiles/mod.rs
+++ b/evm-utils/programs/evm_loader/src/precompiles/mod.rs
@@ -212,7 +212,7 @@ mod test {
     }
     #[test]
     fn check_num_precompiles() {
-        assert_eq!(PRECOMPILES_MAP.len(), 9);
+        assert_eq!(PRECOMPILES_MAP.len(), 4);
     }
 
     #[test]

--- a/evm-utils/programs/evm_loader/src/precompiles/mod.rs
+++ b/evm-utils/programs/evm_loader/src/precompiles/mod.rs
@@ -473,25 +473,17 @@ mod test {
                     .unwrap();
             println!("{}", hex::encode(&result.0.output));
             assert_eq!(
-                result,
-                (
-                    PrecompileOutput {
-                        exit_status: ExitSucceed::Returned,
-                        output: hex!(
-                            "0000000000000000000000009c1185a5c5e9fc54612808977ee8f548b2258d31"
-                        )
-                        .to_vec(),
-                    },
-                    60,
-                    vec![]
-                )
+                result.0,
+                PrecompileOutput {
+                    exit_status: ExitSucceed::Returned,
+                    output: hex!(
+                        "0000000000000000000000009c1185a5c5e9fc54612808977ee8f548b2258d31"
+                    )
+                    .to_vec(),
+                }
             );
 
-            #[cfg(not(feature = "pricefix"))]
             assert_eq!(result.1, 60);
-
-            #[cfg(feature = "pricefix")]
-            assert_eq!(result.1, 600);
         })
     }
 
@@ -525,11 +517,7 @@ mod test {
                 )
             );
 
-            #[cfg(not(feature = "pricefix"))]
             assert_eq!(result.1, 108);
-
-            #[cfg(feature = "pricefix")]
-            assert_eq!(result.1, 3000);
         });
         AccountStructure::testing(0, |accounts: AccountStructure| {
             let precompiles = entrypoint(accounts, true, false);
@@ -545,7 +533,8 @@ mod test {
                     exit_status: ExitSucceed::Returned,
                     output: hex!(
                         "000000000000000000000000c08b5542d177ac6686946920409741463a15dddb"
-                    ).to_vec()
+                    )
+                    .to_vec()
                 }
             );
 
@@ -611,7 +600,10 @@ mod test {
                 (
                     PrecompileOutput {
                         exit_status: ExitSucceed::Returned,
-                        output: hex!("0000000000000000000000000000000000000000000000000000000000000001").to_vec()
+                        output: hex!(
+                            "0000000000000000000000000000000000000000000000000000000000000001"
+                        )
+                        .to_vec()
                     },
                     13_056
                 )
@@ -637,7 +629,10 @@ mod test {
                 (
                     PrecompileOutput {
                         exit_status: ExitSucceed::Returned,
-                        output: hex!("0000000000000000000000000000000000000000000000000000000000000000").to_vec()
+                        output: hex!(
+                            "0000000000000000000000000000000000000000000000000000000000000000"
+                        )
+                        .to_vec()
                     },
                     13_056
                 )
@@ -664,7 +659,10 @@ mod test {
                 (
                     PrecompileOutput {
                         exit_status: ExitSucceed::Returned,
-                        output: hex!("3b01b01ac41f2d6e917c6d6a221ce793802469026d9ab7578fa2e79e4da6aaab").to_vec()
+                        output: hex!(
+                            "3b01b01ac41f2d6e917c6d6a221ce793802469026d9ab7578fa2e79e4da6aaab"
+                        )
+                        .to_vec()
                     },
                     768
                 )
@@ -767,7 +765,8 @@ mod test {
                             0000000000000000000000000000000000000000000000000000000000000000
                             0000000000000000000000000000000000000000000000000000000000000000
                             "
-                        ).to_vec()
+                        )
+                        .to_vec()
                     },
                     150
                 )
@@ -790,7 +789,8 @@ mod test {
                         0000000000000000000000000000000000000000000000000000000000000000
                         0000000000000000000000000000000000000000000000000000000000000000
                         "
-                    ).to_vec()
+                    )
+                    .to_vec()
                 }
             );
         });
@@ -845,7 +845,8 @@ mod test {
                             0000000000000000000000000000000000000000000000000000000000000000
                             0000000000000000000000000000000000000000000000000000000000000000
                             "
-                        ).to_vec()
+                        )
+                        .to_vec()
                     },
                     6000
                 )
@@ -890,7 +891,10 @@ mod test {
                 (
                     PrecompileOutput {
                         exit_status: ExitSucceed::Returned,
-                        output: hex!("0000000000000000000000000000000000000000000000000000000000000001").to_vec()
+                        output: hex!(
+                            "0000000000000000000000000000000000000000000000000000000000000001"
+                        )
+                        .to_vec()
                     },
                     45_000
                 )
@@ -968,7 +972,8 @@ mod test {
                             08c9bcf367e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5
                             d282e6ad7f520e511f6c3e2b8c68059b9442be0454267ce079217e1319cde05b
                             "
-                        ).to_vec()
+                        )
+                        .to_vec()
                     },
                     0
                 )
@@ -1002,7 +1007,8 @@ mod test {
                             ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d1
                             7d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923
                             "
-                        ).to_vec()
+                        )
+                        .to_vec()
                     },
                     12
                 )
@@ -1036,7 +1042,8 @@ mod test {
                             75ab69d3190a562c51aef8d88f1c2775876944407270c42c9844252c26d28752
                             98743e7f6d5ea2f2d3e8d226039cd31b4e426ac4f2d3d666a610c2116fde4735
                             "
-                        ).to_vec()
+                        )
+                        .to_vec()
                     },
                     12
                 )
@@ -1070,7 +1077,8 @@ mod test {
                             b63a380cb2897d521994a85234ee2c181b5f844d2c624c002677e9703449d2fb
                             a551b3a8333bcdf5f2f7e08993d53923de3d64fcc68c034e717b9293fed7a421
                             "
-                        ).to_vec()
+                        )
+                        .to_vec()
                     },
                     1
                 )

--- a/evm-utils/programs/evm_loader/src/precompiles/mod.rs
+++ b/evm-utils/programs/evm_loader/src/precompiles/mod.rs
@@ -487,7 +487,11 @@ mod test {
                 )
             );
 
+            #[cfg(not(feature = "pricefix"))]
             assert_eq!(result.1, 60);
+
+            #[cfg(feature = "pricefix")]
+            assert_eq!(result.1, 600);
         })
     }
 
@@ -508,6 +512,7 @@ mod test {
                 precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
                     .unwrap();
             println!("{}", hex::encode(&result.0.output));
+
             assert_eq!(
                 result,
                 (
@@ -519,7 +524,12 @@ mod test {
                     vec![]
                 )
             );
-            assert_eq!(result.1, 108)
+
+            #[cfg(not(feature = "pricefix"))]
+            assert_eq!(result.1, 108);
+
+            #[cfg(feature = "pricefix")]
+            assert_eq!(result.1, 3000);
         });
         AccountStructure::testing(0, |accounts: AccountStructure| {
             let precompiles = entrypoint(accounts, true, false);
@@ -538,7 +548,12 @@ mod test {
                     ).to_vec()
                 }
             );
-            assert_eq!(result.1, 108)
+
+            #[cfg(not(feature = "pricefix"))]
+            assert_eq!(result.1, 108);
+
+            #[cfg(feature = "pricefix")]
+            assert_eq!(result.1, 3000);
         });
     }
 

--- a/evm-utils/programs/evm_loader/src/precompiles/mod.rs
+++ b/evm-utils/programs/evm_loader/src/precompiles/mod.rs
@@ -516,8 +516,6 @@ mod test {
                     vec![]
                 )
             );
-
-            assert_eq!(result.1, 108);
         });
         AccountStructure::testing(0, |accounts: AccountStructure| {
             let precompiles = entrypoint(accounts, true, false);
@@ -538,11 +536,7 @@ mod test {
                 }
             );
 
-            #[cfg(not(feature = "pricefix"))]
             assert_eq!(result.1, 108);
-
-            #[cfg(feature = "pricefix")]
-            assert_eq!(result.1, 3000);
         });
     }
 
@@ -581,7 +575,7 @@ mod test {
 
         // fermat's little theorem example.
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 0000000000000000000000000000000000000000000000000000000000000001
@@ -593,7 +587,9 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(
                 result,
@@ -605,14 +601,15 @@ mod test {
                         )
                         .to_vec()
                     },
-                    13_056
+                    13_056,
+                    vec![]
                 )
             );
         });
 
         // second example from EIP: zero base.
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 0000000000000000000000000000000000000000000000000000000000000000
@@ -622,7 +619,9 @@ mod test {
                 fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(
                 result,
@@ -634,14 +633,15 @@ mod test {
                         )
                         .to_vec()
                     },
-                    13_056
+                    13_056,
+                    vec![]
                 )
             );
         });
 
         // another example from EIP: zero-padding
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 0000000000000000000000000000000000000000000000000000000000000001
@@ -652,7 +652,9 @@ mod test {
                 80"
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(
                 result,
@@ -664,14 +666,15 @@ mod test {
                         )
                         .to_vec()
                     },
-                    768
+                    768,
+                    vec![]
                 )
             );
         });
 
         // zero-length modulus.
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 0000000000000000000000000000000000000000000000000000000000000001
@@ -681,7 +684,9 @@ mod test {
                 ffff"
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(result.0.output.len(), 0); // shouldn't have written any output.
             assert_eq!(result.1, 0);
@@ -701,7 +706,7 @@ mod test {
         };
 
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 0000000000000000000000000000000000000000000000000000000000000001
@@ -710,13 +715,15 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(result.1, u64::max_value());
         });
 
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 00000000000000000000000000000000000000000000000000000000000000ff
@@ -725,7 +732,9 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(result.1, u64::max_value());
         });
@@ -743,7 +752,7 @@ mod test {
 
         // zero-points additions
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 0000000000000000000000000000000000000000000000000000000000000000
@@ -753,7 +762,9 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(
                 result,
@@ -768,17 +779,20 @@ mod test {
                         )
                         .to_vec()
                     },
-                    150
+                    150,
+                    vec![]
                 )
             );
         });
 
         // no input, should not fail
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = [0u8; 0];
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(
                 result.0,
@@ -797,7 +811,7 @@ mod test {
 
         // should fail - point not on curve
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 1111111111111111111111111111111111111111111111111111111111111111
@@ -807,7 +821,8 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
             assert!(result.is_err());
         });
     }
@@ -824,7 +839,7 @@ mod test {
 
         // zero-point multiplication
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 0000000000000000000000000000000000000000000000000000000000000000
@@ -833,7 +848,9 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(
                 result,
@@ -848,14 +865,15 @@ mod test {
                         )
                         .to_vec()
                     },
-                    6000
+                    6000,
+                    vec![]
                 )
             );
         });
 
         // should fail - point not on curve
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 1111111111111111111111111111111111111111111111111111111111111111
@@ -864,7 +882,8 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
             assert!(result.is_err());
         });
     }
@@ -881,10 +900,12 @@ mod test {
 
         // should not fail, because empty input is a valid input of 0 elements
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = [0u8; 0];
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(
                 result,
@@ -896,14 +917,15 @@ mod test {
                         )
                         .to_vec()
                     },
-                    45_000
+                    45_000,
+                    vec![]
                 )
             );
         });
 
         // should fail - point not on curve
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 1111111111111111111111111111111111111111111111111111111111111111
@@ -915,13 +937,14 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
             assert!(result.is_err());
         });
 
         // should fail - input length is invalid
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 1111111111111111111111111111111111111111111111111111111111111111
@@ -930,7 +953,8 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
             assert!(result.is_err());
         });
     }
@@ -947,7 +971,7 @@ mod test {
 
         // Test vector 4 and expected output from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-152.md#test-vector-4
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 0000000048c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f
@@ -960,7 +984,9 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(
                 result,
@@ -975,14 +1001,15 @@ mod test {
                         )
                         .to_vec()
                     },
-                    0
+                    0,
+                    vec![]
                 )
             );
         });
 
         // Test vector 5 and expected output from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-152.md#test-vector-5
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 0000000c48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f
@@ -995,7 +1022,9 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(
                 result,
@@ -1010,14 +1039,15 @@ mod test {
                         )
                         .to_vec()
                     },
-                    12
+                    12,
+                    vec![]
                 )
             );
         });
 
         // Test vector 6 and expected output from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-152.md#test-vector-6
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 0000000c48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f
@@ -1030,7 +1060,9 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(
                 result,
@@ -1045,14 +1077,15 @@ mod test {
                         )
                         .to_vec()
                     },
-                    12
+                    12,
+                    vec![]
                 )
             );
         });
 
         // Test vector 7 and expected output from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-152.md#test-vector-7
         AccountStructure::testing(0, |accounts| {
-            let precompiles = entrypoint(accounts, true);
+            let precompiles = entrypoint(accounts, true, false);
             let input = hex!(
                 "
                 0000000148c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f
@@ -1065,7 +1098,9 @@ mod test {
                 "
             );
 
-            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
+            let result =
+                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
+                    .unwrap();
 
             assert_eq!(
                 result,
@@ -1080,7 +1115,8 @@ mod test {
                         )
                         .to_vec()
                     },
-                    1
+                    1,
+                    vec![]
                 )
             );
         });

--- a/evm-utils/programs/evm_loader/src/precompiles/mod.rs
+++ b/evm-utils/programs/evm_loader/src/precompiles/mod.rs
@@ -243,7 +243,7 @@ mod test {
         AccountStructure::testing(0, |accounts| {
             let precompiles = entrypoint(accounts, PrecompileSet::No, true);
             assert_eq!(
-                dbg!(precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap_err()),
+                dbg!(precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap_err()),
                 PrecompileFailure::Error { exit_status: ExitError::Other("Failed to find account, account_pk = 29d2S7vB453rNYFdR5Ycwt7y9haRT5fwVwL9zTmBhfV2".into()) } // equal to 0x111..111 in base58
             );
         })
@@ -274,7 +274,7 @@ mod test {
         };
         AccountStructure::testing(0, |accounts| {
             let precompiles = entrypoint(accounts, PrecompileSet::No, false);
-            let precompile_output = dbg!(precompiles.precompiles.get(&addr).unwrap()(
+            let precompile_output = dbg!(precompiles.get(&addr).unwrap()(
                 &input, None, None, &cx, false
             ));
             assert!(matches!(
@@ -310,7 +310,7 @@ mod test {
             ))
             .unwrap();
             let lamports_before = user.lamports().unwrap();
-            let precompile_output = dbg!(precompiles.precompiles.get(&addr).unwrap()(
+            let precompile_output = dbg!(precompiles.get(&addr).unwrap()(
                 &input, None, None, &cx, false
             ));
             assert!(matches!(
@@ -355,7 +355,7 @@ mod test {
             ))
             .unwrap();
             let lamports_before = user.lamports().unwrap();
-            let precompile_output = dbg!(precompiles.precompiles.get(&addr).unwrap()(
+            let precompile_output = dbg!(precompiles.get(&addr).unwrap()(
                 &input, None, None, &cx, false
             ));
             assert!(matches!(
@@ -410,9 +410,7 @@ mod test {
         AccountStructure::testing(0, |accounts: AccountStructure| {
             let precompiles = entrypoint(accounts, PrecompileSet::VelasClassic, false);
             let input = [0u8; 0];
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
             println!("{}", hex::encode(&result.0.output));
             assert_eq!(
                 result,
@@ -443,9 +441,7 @@ mod test {
         AccountStructure::testing(0, |accounts: AccountStructure| {
             let precompiles = entrypoint(accounts, PrecompileSet::VelasClassic, false);
             let input = [1, 2, 3, 4];
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
             println!("{}", hex::encode(&result.0.output));
             assert_eq!(
                 result,
@@ -466,7 +462,7 @@ mod test {
         let addr = H160::from_str("0000000000000000000000000000000000000004").unwrap();
         AccountStructure::testing(0, |accounts: AccountStructure| {
             let precompiles = entrypoint(accounts, PrecompileSet::No, false);
-            assert!(precompiles.precompiles.get(&addr).is_none());
+            assert!(precompiles.get(&addr).is_none());
         })
     }
 
@@ -482,9 +478,7 @@ mod test {
         AccountStructure::testing(0, |accounts: AccountStructure| {
             let precompiles = entrypoint(accounts, PrecompileSet::VelasClassic, false);
             let input = [0u8; 0];
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
             println!("{}", hex::encode(&result.0.output));
             assert_eq!(
                 result.0,
@@ -514,9 +508,7 @@ mod test {
             let precompiles = entrypoint(accounts, PrecompileSet::VelasClassic, false);
             let input = hex!("47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad000000000000000000000000000000000000000000000000000000000000001a650acf9d3f5f0a2c799776a1254355d5f4061762a237396a99a0e0e3fc2bcd6729514a0dacb2e623ac4abd157cb18163ff942280db4d5caad66ddf941ba12e03");
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
             println!("{}", hex::encode(&result.0.output));
 
             assert_eq!(
@@ -535,9 +527,7 @@ mod test {
             let precompiles = entrypoint(accounts, PrecompileSet::VelasClassic, false);
             let input = hex!("47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad000000000000000000000000000000000000000000000000000000000000001b650acf9d3f5f0a2c799776a1254355d5f4061762a237396a99a0e0e3fc2bcd6729514a0dacb2e623ac4abd157cb18163ff942280db4d5caad66ddf941ba12e03");
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
             println!("{}", hex::encode(&result.0.output));
             assert_eq!(
                 result.0,
@@ -601,9 +591,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(
                 result,
@@ -633,9 +621,7 @@ mod test {
                 fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(
                 result,
@@ -666,9 +652,7 @@ mod test {
                 80"
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(
                 result,
@@ -698,9 +682,7 @@ mod test {
                 ffff"
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(result.0.output.len(), 0); // shouldn't have written any output.
             assert_eq!(result.1, 0);
@@ -729,9 +711,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(result.1, u64::max_value());
         });
@@ -746,9 +726,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(result.1, u64::max_value());
         });
@@ -776,9 +754,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(
                 result,
@@ -804,9 +780,7 @@ mod test {
             let precompiles = entrypoint(accounts, PrecompileSet::VelasNext, false);
             let input = [0u8; 0];
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(
                 result.0,
@@ -835,8 +809,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
             assert!(result.is_err());
         });
     }
@@ -862,9 +835,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(
                 result,
@@ -896,8 +867,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
             assert!(result.is_err());
         });
     }
@@ -917,9 +887,7 @@ mod test {
             let precompiles = entrypoint(accounts, PrecompileSet::VelasNext, false);
             let input = [0u8; 0];
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(
                 result,
@@ -951,8 +919,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
             assert!(result.is_err());
         });
 
@@ -967,8 +934,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false);
             assert!(result.is_err());
         });
     }
@@ -998,9 +964,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(
                 result,
@@ -1036,9 +1000,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(
                 result,
@@ -1074,9 +1036,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(
                 result,
@@ -1112,9 +1072,7 @@ mod test {
                 "
             );
 
-            let result =
-                precompiles.precompiles.get(&addr).unwrap()(&input, None, None, &cx, false)
-                    .unwrap();
+            let result = precompiles.get(&addr).unwrap()(&input, None, None, &cx, false).unwrap();
 
             assert_eq!(
                 result,

--- a/evm-utils/programs/evm_loader/src/precompiles/mod.rs
+++ b/evm-utils/programs/evm_loader/src/precompiles/mod.rs
@@ -567,7 +567,7 @@ mod test {
         // // test for potential exp len overflow
         // // this test is slow
         // AccountStructure::testing(0, |accounts| {
-        //     let precompiles = entrypoint(accounts, ActivatePrecompile::VelasClassic);
+        //     let precompiles = entrypoint(accounts, ActivatePrecompile::VelasNext);
         //     let input = hex!(
         //         "
         //         00000000000000000000000000000000000000000000000000000000000000ff

--- a/evm-utils/programs/evm_loader/src/processor.rs
+++ b/evm-utils/programs/evm_loader/src/processor.rs
@@ -2,6 +2,8 @@ use std::cell::RefMut;
 use std::fmt::Write;
 use std::ops::DerefMut;
 
+use crate::precompiles::{build_precompile_map, PRECOMPILES_MAP};
+
 use super::account_structure::AccountStructure;
 use super::instructions::{
     EvmBigTransaction, EvmInstruction, ExecuteTransaction, FeePayerType,
@@ -65,7 +67,16 @@ impl EvmProcessor {
         let borsh_serialization_enabled = invoke_context
             .feature_set
             .is_active(&solana_sdk::feature_set::velas::evm_instruction_borsh_serialization::id());
+        let evm_new_precompiles = invoke_context
+            .feature_set
+            .is_active(&solana_sdk::feature_set::velas::evm_new_precompiles::id());
+
         let cross_execution = invoke_context.get_stack_height() != 1;
+
+        PRECOMPILES_MAP
+            .set(build_precompile_map(evm_new_precompiles))
+            .ok()
+            .unwrap();
 
         if cross_execution && !cross_execution_enabled {
             ic_msg!(invoke_context, "Cross-Program evm execution not enabled.");

--- a/rpc/src/evm_rpc_impl/mod.rs
+++ b/rpc/src/evm_rpc_impl/mod.rs
@@ -854,7 +854,7 @@ impl TraceERPC for TraceErpcImpl {
                     tx_hash,
                     true,
                     simulation_entrypoint(
-                        executor.support_precompile(),
+                        PrecompileSet::VelasClassic,
                         &evm_keyed_account,
                         &user_accounts,
                     ),
@@ -1181,7 +1181,7 @@ fn call_inner(
             tx_hash,
             true,
             simulation_entrypoint(
-                executor.support_precompile(),
+                PrecompileSet::VelasClassic,
                 &evm_keyed_account,
                 &user_accounts,
             ),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -425,7 +425,7 @@ pub mod velas {
     }
 
     pub mod evm_new_precompiles {
-        solana_sdk::declare_id!("X9AHGkHztTz1DBDaQrc2FfX8zWv6mFg7ywUhspu72nQ");
+        solana_sdk::declare_id!("4NLsdp3QnxQaERdfVqSMDczFQLeLokqGXBWpp1EJVLme");
     }
 }
 lazy_static! {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -423,6 +423,10 @@ pub mod velas {
     pub mod evm_instruction_borsh_serialization {
         solana_sdk::declare_id!("9NUVkN3PYJXz6z8cUgtGHYWd1CmcYF7ci3a552rASPQw");
     }
+
+    pub mod evm_new_precompiles {
+        solana_sdk::declare_id!("X9AHGkHztTz1DBDaQrc2FfX8zWv6mFg7ywUhspu72nQ");
+    }
 }
 lazy_static! {
     /// Map of feature identifiers to user-visible description


### PR DESCRIPTION
### Add new precompiles:
- Big integer modular exponentiation
[EIP-198](https://eips.ethereum.org/EIPS/eip-198), [EIP-2565](https://eips.ethereum.org/EIPS/eip-2565)
- Addition and scalar multiplication on the elliptic curve alt_bn128
[EIP-196](https://eips.ethereum.org/EIPS/eip-196), [EIP-197](https://eips.ethereum.org/EIPS/eip-197), [EIP-1108](https://eips.ethereum.org/EIPS/eip-1108)
- BLAKE2 compression function
[EIP-152](https://eips.ethereum.org/EIPS/eip-152)