### PR TITLE
Feat(evm-bridge): add whitelist to pay for evm transactions

### DIFF
--- a/evm-utils/evm-bridge/src/main.rs
+++ b/evm-utils/evm-bridge/src/main.rs
@@ -1282,6 +1282,7 @@ mod tests {
             max_logs_blocks: 0u64,
             pool: EthPool::new(SystemClock),
             min_gas_price: 0.into(),
+            whitelist: vec![],
         });
 
         let rpc = BridgeErpcImpl {};

--- a/evm-utils/evm-bridge/src/main.rs
+++ b/evm-utils/evm-bridge/src/main.rs
@@ -396,7 +396,7 @@ impl EvmBridge {
     }
 
     fn should_pay_for_gas(&self, tx: &Transaction) -> bool {
-        !self.whitelist.is_empty() && self.whitelist.iter().any(|f| f.filter(tx))
+        !self.whitelist.is_empty() && self.whitelist.iter().any(|f| f.is_match(tx))
     }
 }
 

--- a/evm-utils/evm-bridge/src/pool.rs
+++ b/evm-utils/evm-bridge/src/pool.rs
@@ -828,7 +828,7 @@ async fn deploy_big_tx(
     let mut native_fee_used = false;
     let ix = if bridge.borsh_encoding {
         let mut fee_type = FeePayerType::Evm;
-        if bridge.should_pay_for_gas(&tx) {
+        if bridge.should_pay_for_gas(tx) {
             fee_type = FeePayerType::Native;
             native_fee_used = true;
             info!("Using Native fee for tx: {}", tx.tx_id_hash());

--- a/evm-utils/evm-bridge/src/tx_filter.rs
+++ b/evm-utils/evm-bridge/src/tx_filter.rs
@@ -1,0 +1,19 @@
+use evm_rpc::Bytes;
+use evm_state::{Address, Transaction, TransactionAction};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub enum TxFilter {
+    InputStartsWith(Address, Bytes),
+}
+
+impl TxFilter {
+    pub fn filter(&self, tx: &Transaction) -> bool {
+        match self {
+            Self::InputStartsWith(addr, bytes) => {
+                matches!(tx.action, TransactionAction::Call(contract) if contract == *addr)
+                    && tx.input.starts_with(&bytes.0)
+            }
+        }
+    }
+}

--- a/evm-utils/evm-bridge/src/tx_filter.rs
+++ b/evm-utils/evm-bridge/src/tx_filter.rs
@@ -4,15 +4,18 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub enum TxFilter {
-    InputStartsWith(Address, Bytes),
+    InputStartsWith{
+        contract: Address,
+        input_prefix: Bytes
+    },
 }
 
 impl TxFilter {
-    pub fn filter(&self, tx: &Transaction) -> bool {
+    pub fn is_match(&self, tx: &Transaction) -> bool {
         match self {
-            Self::InputStartsWith(addr, bytes) => {
-                matches!(tx.action, TransactionAction::Call(contract) if contract == *addr)
-                    && tx.input.starts_with(&bytes.0)
+            Self::InputStartsWith { contract, input_prefix } => {
+                matches!(tx.action, TransactionAction::Call(addr) if addr == *contract)
+                    && tx.input.starts_with(&input_prefix.0)
             }
         }
     }


### PR DESCRIPTION
Added `--whitelist-path` arg to bridge. It expects a path to json file with array of filters

Only "InputStartsWith" is supported so far.
Whitelist config example:
```
[
	{ "InputStartsWith": [ "0xC56c3022a16FC3f7eA7538034266D6aDf290B095", "0xe2a2d66a" ] }
]
```
This means that all transactions to 0xC56c3022a16FC3f7eA7538034266D6aDf290B095 that will have it's input starting with 0xe2a2d66a will be payed by a bridge.