### PR TITLE
feat(evm-utils/evm-state): move velas-chain to fast_rlp tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +234,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a8c1df849285fbacd587de7818cc7d13be6cd2cbcd47a04fb1801b0e2706e33"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,9 +262,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.15"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b32c5ea3aabaf4deb5f5ced2d688ec0844c881c9e6c696a8b769a05fc691e62"
+checksum = "113713495a32dd0ab52baf5c10044725aa3aec00b31beda84218e469029b72a3"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -654,12 +675,6 @@ dependencies = [
  "byteorder",
  "iovec",
 ]
-
-[[package]]
-name = "bytes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
 name = "bytes"
@@ -1097,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -1876,7 +1891,7 @@ name = "evm"
 version = "0.35.0"
 source = "git+https://github.com/velas/evm?tag=v0.35-with-traces#90a980bb9d7ccbb21b2897e71b889847f7beeade"
 dependencies = [
- "auto_impl",
+ "auto_impl 0.5.0",
  "environmental",
  "ethereum",
  "evm-core",
@@ -2023,7 +2038,7 @@ name = "evm-runtime"
 version = "0.35.0"
 source = "git+https://github.com/velas/evm?tag=v0.35-with-traces#90a980bb9d7ccbb21b2897e71b889847f7beeade"
 dependencies = [
- "auto_impl",
+ "auto_impl 0.5.0",
  "environmental",
  "evm-core",
  "primitive-types",
@@ -2038,11 +2053,12 @@ dependencies = [
  "auto_enums",
  "bincode",
  "borsh",
- "bytes 0.6.0",
+ "bytes 1.4.0",
  "criterion",
  "dashmap 4.0.2",
  "derivative",
  "derive_more",
+ "etcommon-hexutil",
  "ethabi",
  "ethbloom 0.11.1",
  "evm",
@@ -2117,6 +2133,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.2.2"
+source = "git+https://github.com/velas/fastrlp?tag=first-release#c353507bc30032ac9305176603896ae5111c251a"
+dependencies = [
+ "arrayvec",
+ "auto_impl 1.0.1",
+ "bytes 1.4.0",
+ "ethereum-types",
+ "fastrlp-derive",
+ "thiserror",
+]
+
+[[package]]
+name = "fastrlp-derive"
+version = "0.1.4"
+source = "git+https://github.com/velas/fastrlp?tag=first-release#c353507bc30032ac9305176603896ae5111c251a"
+dependencies = [
+ "bytes 1.4.0",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2457,7 +2497,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "bstr",
  "fnv",
  "log 0.4.17",
@@ -2496,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes 1.4.0",
  "fnv",
@@ -3037,7 +3077,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes 1.0.10",
- "rustix 0.37.11",
+ "rustix 0.37.13",
  "windows-sys 0.48.0",
 ]
 
@@ -3300,9 +3340,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libloading"
@@ -3415,9 +3455,9 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
 name = "lock_api"
@@ -3864,9 +3904,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "97ea2d98598bf9ada7ea6ee8a30fb74f9156b63bbe495d64ec2b87c269d2dda3"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -3896,18 +3936,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.25.2+1.1.1t"
+version = "111.25.3+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320708a054ad9b3bf314688b5db87cf4d6683d64cfc835e2337924ae62bf4431"
+checksum = "924757a6a226bf60da5f7dd0311a34d2b52283dd82ddeb103208ddc66362f80c"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
 dependencies = [
  "cc",
  "libc",
@@ -4506,7 +4546,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift 0.3.0",
- "regex-syntax",
+ "regex-syntax 0.6.29",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -5070,13 +5110,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.0.1",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -5090,6 +5130,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "repair-check"
@@ -5223,9 +5269,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -5279,15 +5325,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
 dependencies = [
  "bitflags",
  "errno 0.3.1",
  "io-lifetimes 1.0.10",
  "libc",
- "linux-raw-sys 0.3.1",
+ "linux-raw-sys 0.3.3",
  "windows-sys 0.48.0",
 ]
 
@@ -8246,7 +8292,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.11",
+ "rustix 0.37.13",
  "windows-sys 0.45.0",
 ]
 
@@ -9003,13 +9049,16 @@ checksum = "0de5f738ceab88e2491a94ddc33c3feeadfa95fedc60363ef110845df12f3878"
 [[package]]
 name = "triedb"
 version = "0.5.0"
-source = "git+https://github.com/velas/triedb?tag=optimal_children#16643d9ee244b0ff4e9e69281a39a7e79df3c4f1"
+source = "git+https://github.com/velas/triedb?tag=fast_rlp#5c4b59356dd27d74be96ee51d755cf3a3f361046"
 dependencies = [
  "anyhow",
+ "backtrace",
  "bincode",
+ "bytes 1.4.0",
  "dashmap 4.0.2",
  "derivative",
  "etcommon-hexutil",
+ "fastrlp",
  "log 0.4.17",
  "primitive-types",
  "rayon",

--- a/evm-utils/evm-state/Cargo.toml
+++ b/evm-utils/evm-state/Cargo.toml
@@ -11,7 +11,7 @@ secp256k1 = { version = "0.19.0", features = ["recovery", "global-context"] }
 rand2 = { version = "=0.6.1", package = "rand" }
 rocksdb = { git = "https://github.com/velas/rust-rocksdb", version = "0.19.0", default-features = false }
 # rocksdb = { version = "0.16.0", default-features = false }
-triedb = { git = "https://github.com/velas/triedb", tag = "optimal_children", features = ["rocksdb"] }
+triedb = { git = "https://github.com/velas/triedb", tag = "fast_rlp", features = ["rocksdb"] }
 # triedb = { path = "../../../triedb",  features = ["rocksdb"] }
 
 primitive-types = { version = "0.11.0", features = ["borsh"] }
@@ -19,6 +19,7 @@ keccak-hash = "0.9.0"
 log = "0.4.11"
 simple_logger = "2.2"
 hex = "0.4.2"
+etcommon-hexutil = "0.2.4"
 serde = "1.0"
 sha3 = "0.9.1"
 rand = "0.8.3"
@@ -28,7 +29,7 @@ anyhow = "1.0.34"
 bincode = "1.3.1"
 borsh = "0.9.3"
 lazy_static = "1.4.0"
-bytes = "0.6.0"
+bytes = "1"
 snafu = "0.7"
 derive_more = "0.99.11"
 tempfile = "3.1.0"

--- a/evm-utils/evm-state/src/storage/inspectors.rs
+++ b/evm-utils/evm-state/src/storage/inspectors.rs
@@ -49,7 +49,7 @@ pub mod encoding {
     where
         T: DataInspector<K, V>,
         K: TryFromSlice,
-        V: rlp::Decodable,
+        V: for<'r> triedb::rlp::Decodable<'r>,
     {
         fn inspect_data_raw<Data: AsRef<[u8]>>(&self, key: Vec<u8>, value: Data) -> Result<()> {
             let key = TryFromSlice::try_from_slice(&key)?;
@@ -93,11 +93,12 @@ pub mod encoding {
 
     fn data_from_bytes<Data: AsRef<[u8]>, Value>(data: Data) -> Result<Value>
     where
-        Value: rlp::Decodable,
+        Value: for<'r> triedb::rlp::Decodable<'r>,
     {
-        let rlp = rlp::Rlp::new(data.as_ref());
-        trace!("rlp: {:?}", rlp);
-        let t = Value::decode(&rlp)?;
+        trace!("rlp: {:?}", hexutil::to_hex(data.as_ref()));
+
+        let t = triedb::rlp::decode(data.as_ref())?;
+
         Ok(t)
     }
 }

--- a/evm-utils/evm-state/src/storage/walker.rs
+++ b/evm-utils/evm-state/src/storage/walker.rs
@@ -1,7 +1,6 @@
 use std::{borrow::Borrow, sync::Arc};
 
 use primitive_types::H256;
-use rlp::Rlp;
 use triedb::merkle::{MerkleNode, MerkleValue, Leaf, Extension, Branch};
 
 use anyhow::{anyhow, Result};
@@ -58,9 +57,8 @@ where
                 .ok_or_else(|| anyhow!("hash {:?} not found in database", hash))?;
             trace!("raw bytes: {:?}", bytes);
 
-            let rlp = Rlp::new(bytes.as_slice());
-            trace!("rlp: {:?}", rlp);
-            let node = MerkleNode::decode(&rlp)?;
+
+            let node = triedb::rlp::decode(&bytes)?;
             debug!("node: {:?}", node);
 
             self.process_node(nibble, &node)?;

--- a/evm-utils/evm-state/src/types.rs
+++ b/evm-utils/evm-state/src/types.rs
@@ -1,11 +1,12 @@
+use bytes::BufMut;
 use derive_more::{AsRef, From, Into};
 use itertools::Itertools;
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 
 use triedb::empty_trie_hash;
+use triedb::rlp::{Encodable, Decodable};
 
 use crate::TransactionReceipt;
 use auto_enums::auto_enum;
@@ -94,23 +95,46 @@ impl AccountState {
 }
 
 impl Encodable for AccountState {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(3)
-            .append(&self.nonce)
-            .append(&self.balance)
-            .append(&self.code);
+    fn encode(&self,out: &mut dyn BufMut) {
+        unimplemented!();
+    }
+    fn length(&self) -> usize {
+        unimplemented!();
+        
     }
 }
 
-impl Decodable for AccountState {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        Ok(Self {
-            nonce: rlp.val_at(0)?,
-            balance: rlp.val_at(1)?,
-            code: rlp.val_at(2)?,
-        })
+impl<'de> Decodable<'de> for AccountState {
+    fn decode(buf: &mut &'de [u8]) -> Result<Self, triedb::rlp::decode::DecodeError> {
+        unimplemented!();
     }
 }
+
+#[cfg(test)]
+mod account_state_old_rlp {
+    use rlp::{Decodable as OldDecodable, DecoderError as OldDecoderError, Encodable as OldEncodable, Rlp as RlpOld, RlpStream as RlpStreamOld};
+    use super::AccountState;
+    impl OldEncodable for AccountState {
+        fn rlp_append(&self, s: &mut RlpStreamOld) {
+            s.begin_list(3)
+                .append(&self.nonce)
+                .append(&self.balance)
+                .append(&self.code);
+        }
+    }
+
+    impl OldDecodable for AccountState {
+        fn decode(rlp: &RlpOld) -> Result<Self, OldDecoderError> {
+            Ok(Self {
+                nonce: rlp.val_at(0)?,
+                balance: rlp.val_at(1)?,
+                code: rlp.val_at(2)?,
+            })
+        }
+    }   
+}
+
+
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, From, Into, AsRef, Serialize, Deserialize)]
 pub struct Code(Vec<u8>);
@@ -134,16 +158,42 @@ impl Code {
 }
 
 impl Encodable for Code {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        self.0.rlp_append(s)
+    fn encode(&self,out: &mut dyn BufMut) {
+        unimplemented!();
+    }
+    fn length(&self) -> usize {
+        unimplemented!();
+        
     }
 }
 
-impl Decodable for Code {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        <_>::decode(rlp).map(Self)
+impl<'de> Decodable<'de> for Code {
+    fn decode(buf: &mut &'de [u8]) -> Result<Self, triedb::rlp::decode::DecodeError> {
+        unimplemented!();
     }
 }
+
+#[cfg(test)]
+mod code_old_rlp {
+    use rlp::{Decodable as OldDecodable, DecoderError as OldDecoderError, Encodable as OldEncodable, Rlp as RlpOld, RlpStream as RlpStreamOld};
+    use super::Code;
+
+    impl OldEncodable for Code {
+        fn rlp_append(&self, s: &mut RlpStreamOld) {
+            self.0.rlp_append(s)
+        }
+    }
+
+    impl OldDecodable for Code {
+        fn decode(rlp: &RlpOld) -> Result<Self, OldDecoderError> {
+            <Vec<u8> as OldDecodable>::decode(rlp).map(Self)
+        }
+    }
+}
+
+
+
+
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 // TODO: restrict roots modification anywhere outside State Apply logic
@@ -174,24 +224,48 @@ impl Default for Account {
     }
 }
 
-impl Encodable for Account {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(4)
-            .append(&self.nonce)
-            .append(&self.balance)
-            .append(&self.storage_root)
-            .append(&self.code_hash);
+#[cfg(test)]
+mod account_old_rlp {
+    use rlp::{Decodable as OldDecodable, DecoderError as OldDecoderError, Encodable as OldEncodable, Rlp as RlpOld, RlpStream as RlpStreamOld};
+    use super::Account;
+    
+    impl OldEncodable for Account {
+        fn rlp_append(&self, s: &mut RlpStreamOld) {
+            s.begin_list(4)
+                .append(&self.nonce)
+                .append(&self.balance)
+                .append(&self.storage_root)
+                .append(&self.code_hash);
+        }
+    }
+
+    impl OldDecodable for Account {
+        fn decode(rlp: &RlpOld) -> Result<Self, OldDecoderError> {
+            Ok(Self {
+                nonce: rlp.val_at(0)?,
+                balance: rlp.val_at(1)?,
+                storage_root: rlp.val_at(2)?,
+                code_hash: rlp.val_at(3)?,
+            })
+        }
     }
 }
 
-impl Decodable for Account {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        Ok(Self {
-            nonce: rlp.val_at(0)?,
-            balance: rlp.val_at(1)?,
-            storage_root: rlp.val_at(2)?,
-            code_hash: rlp.val_at(3)?,
-        })
+
+impl Encodable for Account {
+    fn encode(&self,out: &mut dyn BufMut) {
+        unimplemented!();
+    }
+    fn length(&self) -> usize {
+        unimplemented!();
+        
+    }
+}
+
+
+impl<'de> Decodable<'de> for Account {
+    fn decode(buf: &mut &'de [u8]) -> Result<Self, triedb::rlp::decode::DecodeError> {
+        unimplemented!();
     }
 }
 
@@ -347,6 +421,97 @@ pub struct BlockHeader {
     pub version: BlockVersion,
 }
 
+impl BlockHeader {
+    pub fn hash(&self) -> H256 {
+        unimplemented!();
+    }
+}
+
+impl Encodable for BlockHeader {
+    fn encode(&self,out: &mut dyn BufMut) {
+        unimplemented!();
+    }
+    fn length(&self) -> usize {
+        unimplemented!();
+        
+    }
+}
+
+#[cfg(test)]
+mod block_header_old_rlp {
+    
+    use keccak_hash::H256;
+    use primitive_types::{H160, U256};
+    use rlp::{Encodable as OldEncodable, RlpStream as RlpStreamOld};
+    use sha3::Keccak256;
+    use crate::{empty_ommers_hash, H64};
+
+    use super::BlockHeader;
+    use super::BlockVersion;
+
+    impl OldEncodable for BlockHeader {
+        fn rlp_append(&self, s: &mut RlpStreamOld) {
+            match self.version {
+                BlockVersion::InitVersion => self.rlp_append_legacy(s),
+                BlockVersion::VersionConsistentHashes => self.rlp_append_newer(s),
+            }
+        }
+    }
+    impl BlockHeader {
+        pub fn hash_old(&self) -> H256 {
+            let mut stream = RlpStreamOld::new();
+            self.rlp_append(&mut stream);
+            H256::from_slice(Keccak256::digest(stream.as_raw()).as_slice())
+        }
+
+        fn rlp_append_legacy(&self, s: &mut RlpStreamOld) {
+            const EMPTH_HASH: H256 = H256::zero();
+            const EXTRA_DATA: &[u8; 32] = b"Velas EVM compatibility layer...";
+            let extra_data = H256::from_slice(EXTRA_DATA);
+            s.begin_list(15);
+            s.append(&self.parent_hash);
+            s.append(&EMPTH_HASH); // ommers/unkles is impossible
+            s.append(&H160::from(EMPTH_HASH)); // Beneficiar address is empty, because reward received in native chain
+            s.append(&self.state_root);
+            s.append(&self.transactions_root);
+            s.append(&self.receipts_root);
+            s.append(&self.logs_bloom);
+            s.append(&EMPTH_HASH); // difficulty, is emtpy
+            s.append(&U256::from(self.block_number));
+            s.append(&U256::from(self.gas_limit));
+            s.append(&U256::from(self.gas_used));
+            s.append(&self.timestamp);
+            s.append(&extra_data);
+            s.append(&self.native_chain_hash); // mix hash is not available in PoS chains, using native chain hash.
+            s.append(&self.native_chain_slot); // nonce like mix hash is not available in PoS, using native chain slot.
+        }
+
+        fn rlp_append_newer(&self, s: &mut RlpStreamOld) {
+            const EMPTH_HASH: H256 = H256::zero();
+            const ZERO_DIFFICULTY: U256 = U256::zero();
+            const EXTRA_DATA: &[u8; 32] = b"Velas EVM compatibility layer.v2";
+            let extra_data = H256::from_slice(EXTRA_DATA);
+            let nonce = H64::from_low_u64_be(self.native_chain_slot);
+            s.begin_list(15);
+            s.append(&self.parent_hash);
+            s.append(&empty_ommers_hash()); // ommers/unkles is impossible
+            s.append(&H160::from(EMPTH_HASH)); // Beneficiar address is empty, because reward received in native chain
+            s.append(&self.state_root);
+            s.append(&self.transactions_root);
+            s.append(&self.receipts_root);
+            s.append(&self.logs_bloom);
+            s.append(&ZERO_DIFFICULTY); // difficulty, is zero
+            s.append(&U256::from(self.block_number));
+            s.append(&U256::from(self.gas_limit));
+            s.append(&U256::from(self.gas_used));
+            s.append(&self.timestamp);
+            s.append(&extra_data);
+            s.append(&self.native_chain_hash); // mix hash is not available in PoS chains, using native chain hash.
+            s.append(&nonce); // nonce like mix hash is not available in PoS, using native chain slot but as 8 bytes array.
+        }
+    }
+}
+
 // TODO: Add transactions in block
 impl BlockHeader {
     #[allow(clippy::too_many_arguments)]
@@ -394,57 +559,8 @@ impl BlockHeader {
         }
     }
 
-    pub fn hash(&self) -> H256 {
-        let mut stream = RlpStream::new();
-        self.rlp_append(&mut stream);
-        H256::from_slice(Keccak256::digest(stream.as_raw()).as_slice())
-    }
 
-    pub fn rlp_append_legacy(&self, s: &mut RlpStream) {
-        const EMPTH_HASH: H256 = H256::zero();
-        const EXTRA_DATA: &[u8; 32] = b"Velas EVM compatibility layer...";
-        let extra_data = H256::from_slice(EXTRA_DATA);
-        s.begin_list(15);
-        s.append(&self.parent_hash);
-        s.append(&EMPTH_HASH); // ommers/unkles is impossible
-        s.append(&H160::from(EMPTH_HASH)); // Beneficiar address is empty, because reward received in native chain
-        s.append(&self.state_root);
-        s.append(&self.transactions_root);
-        s.append(&self.receipts_root);
-        s.append(&self.logs_bloom);
-        s.append(&EMPTH_HASH); // difficulty, is emtpy
-        s.append(&U256::from(self.block_number));
-        s.append(&U256::from(self.gas_limit));
-        s.append(&U256::from(self.gas_used));
-        s.append(&self.timestamp);
-        s.append(&extra_data);
-        s.append(&self.native_chain_hash); // mix hash is not available in PoS chains, using native chain hash.
-        s.append(&self.native_chain_slot); // nonce like mix hash is not available in PoS, using native chain slot.
-    }
 
-    pub fn rlp_append_newer(&self, s: &mut RlpStream) {
-        const EMPTH_HASH: H256 = H256::zero();
-        const ZERO_DIFFICULTY: U256 = U256::zero();
-        const EXTRA_DATA: &[u8; 32] = b"Velas EVM compatibility layer.v2";
-        let extra_data = H256::from_slice(EXTRA_DATA);
-        let nonce = H64::from_low_u64_be(self.native_chain_slot);
-        s.begin_list(15);
-        s.append(&self.parent_hash);
-        s.append(&empty_ommers_hash()); // ommers/unkles is impossible
-        s.append(&H160::from(EMPTH_HASH)); // Beneficiar address is empty, because reward received in native chain
-        s.append(&self.state_root);
-        s.append(&self.transactions_root);
-        s.append(&self.receipts_root);
-        s.append(&self.logs_bloom);
-        s.append(&ZERO_DIFFICULTY); // difficulty, is zero
-        s.append(&U256::from(self.block_number));
-        s.append(&U256::from(self.gas_limit));
-        s.append(&U256::from(self.gas_used));
-        s.append(&self.timestamp);
-        s.append(&extra_data);
-        s.append(&self.native_chain_hash); // mix hash is not available in PoS chains, using native chain hash.
-        s.append(&nonce); // nonce like mix hash is not available in PoS, using native chain slot but as 8 bytes array.
-    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -453,14 +569,6 @@ pub struct Block {
     pub transactions: Vec<(crate::H256, TransactionReceipt)>,
 }
 
-impl Encodable for BlockHeader {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        match self.version {
-            BlockVersion::InitVersion => self.rlp_append_legacy(s),
-            BlockVersion::VersionConsistentHashes => self.rlp_append_newer(s),
-        }
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Maybe<T> {
@@ -480,10 +588,11 @@ impl<T> From<Maybe<T>> for Option<T> {
 mod transaction_roots {
 
     use crate::{Log, TransactionReceipt, H256, U256};
+    use bytes::BufMut;
     use ethbloom::Bloom;
-    use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
     use triedb::gc::{MapWithCounterCached, TrieCollection};
     use triedb::FixedTrieMut;
+    use triedb::rlp::{Encodable, Decodable};
 
     #[derive(Clone, Debug)]
     pub struct EthereumReceipt {
@@ -491,6 +600,22 @@ mod transaction_roots {
         pub log_bloom: Bloom,
         pub logs: Vec<Log>,
         pub status: u8,
+    }
+
+    impl Encodable for EthereumReceipt {
+        fn encode(&self,out: &mut dyn BufMut) {
+            unimplemented!();
+        }
+        fn length(&self) -> usize {
+            unimplemented!();
+        
+        }
+    }
+
+    impl<'de> Decodable<'de> for EthereumReceipt {
+        fn decode(buf: &mut &'de [u8]) -> Result<Self, triedb::rlp::decode::DecodeError> {
+            unimplemented!();
+        }
     }
 
     impl<'a> From<&'a TransactionReceipt> for EthereumReceipt {
@@ -503,33 +628,41 @@ mod transaction_roots {
             }
         }
     }
+    #[cfg(test)]
+    mod ethereum_receipt_old_rlp {
 
-    impl Encodable for EthereumReceipt {
-        fn rlp_append(&self, s: &mut RlpStream) {
-            s.begin_list(4);
-            s.append(&self.status);
-            s.append(&self.gas_used);
-            s.append(&self.log_bloom);
-            s.append_list(&self.logs);
+        use rlp::{Decodable as OldDecodable, DecoderError as OldDecoderError, Encodable as OldEncodable, Rlp as RlpOld, RlpStream as RlpStreamOld};
+        use super::EthereumReceipt;
+        
+        impl OldEncodable for EthereumReceipt {
+            fn rlp_append(&self, s: &mut RlpStreamOld) {
+                s.begin_list(4);
+                s.append(&self.status);
+                s.append(&self.gas_used);
+                s.append(&self.log_bloom);
+                s.append_list(&self.logs);
+            }
+        }
+
+        impl OldDecodable for EthereumReceipt {
+            fn decode(rlp: &RlpOld<'_>) -> Result<Self, OldDecoderError> {
+                Ok(EthereumReceipt {
+                    gas_used: rlp.val_at(1)?,
+                    log_bloom: rlp.val_at(2)?,
+                    logs: rlp.list_at(3)?,
+                    status: rlp.val_at(0)?,
+                })
+            }
         }
     }
 
-    impl Decodable for EthereumReceipt {
-        fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
-            Ok(EthereumReceipt {
-                gas_used: rlp.val_at(1)?,
-                log_bloom: rlp.val_at(2)?,
-                logs: rlp.list_at(3)?,
-                status: rlp.val_at(0)?,
-            })
-        }
-    }
+
 
     pub fn transactions_root<'a>(receipts: impl Iterator<Item = &'a TransactionReceipt>) -> H256 {
         fn no_childs(_: &[u8]) -> Vec<H256> {
             vec![]
         }
-        let trie_c = TrieCollection::new(MapWithCounterCached::default());
+        let trie_c: TrieCollection<_> = TrieCollection::new(MapWithCounterCached::default());
 
         let mut root = trie_c.empty_guard(no_childs);
         for (i, receipt) in receipts.enumerate() {
@@ -619,7 +752,7 @@ mod tests {
 
     // Ethereum header type for tests
     #[derive(Clone, Debug, PartialEq, Eq)]
-    pub struct Header {
+    pub struct TestHeader {
         pub parent_hash: H256,
         pub ommers_hash: H256,
         pub beneficiary: Address,
@@ -637,7 +770,7 @@ mod tests {
         pub nonce: H64,
     }
 
-    impl Encodable for Header {
+    impl OldEncodable for TestHeader {
         fn rlp_append(&self, s: &mut RlpStream) {
             s.begin_list(15);
             s.append(&self.parent_hash);
@@ -658,8 +791,8 @@ mod tests {
         }
     }
 
-    impl Decodable for Header {
-        fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    impl OldDecodable for TestHeader {
+        fn decode(rlp: &Rlp) -> Result<Self, OldDecoderError> {
             Ok(Self {
                 parent_hash: rlp.val_at(0)?,
                 ommers_hash: rlp.val_at(1)?,
@@ -931,7 +1064,7 @@ mod tests {
         let block_bytes = block.rlp_bytes();
         println!("debug {:x}", block_bytes);
         let rlp = Rlp::new(&block_bytes);
-        let header: Header = rlp.as_val().unwrap();
+        let header: TestHeader = rlp.as_val().unwrap();
         assert_eq!(
             Keccak256::digest(&rlp::encode(&header).to_vec()).as_slice(),
             block.hash().as_bytes()
@@ -1003,7 +1136,7 @@ mod tests {
         println!("debug {:x}", block_bytes);
 
         let rlp = Rlp::new(&block_bytes);
-        let header: Header = rlp.as_val().unwrap();
+        let header: TestHeader = rlp.as_val().unwrap();
         assert_eq!(
             Keccak256::digest(&rlp::encode(&header).to_vec()).as_slice(),
             block.hash().as_bytes()

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { version = "1.14.1", features = ["full"] }
 evm-state = { path = "../evm-utils/evm-state" }
 evm-rpc = { path = "../evm-utils/evm-rpc" }
 solana-evm-loader-program = { path = "../evm-utils/programs/evm_loader" }
-triedb = { git = "https://github.com/velas/triedb", tag = "optimal_children", features = ["rocksdb"] }
+triedb = { git = "https://github.com/velas/triedb", tag = "fast_rlp", features = ["rocksdb"] }
 rlp = "0.5.0"
 anyhow = "1.0.43"
 rayon = "1.5.0"


### PR DESCRIPTION
Probably will be rejected as scope is too big for first iteration.
A smaller version with both libs used will be merged first instead.
#### Problem
Implement fast-rlp serialization for all ethereum types, check encoding hasn't changed compared to rlp
#### Summary of Changes

Fixes #
